### PR TITLE
feat: recent

### DIFF
--- a/main/models/abstract-track-list.js
+++ b/main/models/abstract-track-list.js
@@ -79,22 +79,18 @@ module.exports = class AbstractTrackList extends Model {
                 )
               : trackList.trackIds || []
           }
-          if (savedList.trackIds.length) {
-            // one can not update with sparse data: we have to get previous columns
-            for (const col of Object.keys(trackList)) {
-              if (
-                col !== 'trackIds' &&
-                col !== 'removedTrackIds' &&
-                col !== 'refs' &&
-                trackList[col] !== undefined
-              ) {
-                savedList[col] = trackList[col]
-              }
+          // one can not update with sparse data: we have to get previous columns
+          for (const col of Object.keys(trackList)) {
+            if (
+              col !== 'trackIds' &&
+              col !== 'removedTrackIds' &&
+              col !== 'refs' &&
+              trackList[col] !== undefined
+            ) {
+              savedList[col] = trackList[col]
             }
-            saved.push(savedList)
-          } else {
-            removedIds.push(trackList.id)
           }
+          saved.push(savedList)
           return { saved, removedIds }
         },
         { saved: [], removedIds: [] }
@@ -112,10 +108,6 @@ module.exports = class AbstractTrackList extends Model {
             .join(', ')}`,
           [trx(this.name).insert(saved.map(serialize))]
         )
-      }
-      if (removedIds.length) {
-        this.logger.debug({ ids: removedIds }, `removing`)
-        await trx(this.name).whereIn('id', removedIds).delete()
       }
       return { saved, removedIds }
     })

--- a/main/models/migrations/004-recent.js
+++ b/main/models/migrations/004-recent.js
@@ -1,0 +1,14 @@
+'use strict'
+
+exports.up = async function (db) {
+  await db('playlists').insert({
+    id: 151120,
+    name: 'recent',
+    trackIds: JSON.stringify([]),
+    refs: JSON.stringify([])
+  })
+}
+
+exports.down = async function (db) {
+  await db('playlists').where('id', 151120).delete()
+}

--- a/main/utils/logger.js
+++ b/main/utils/logger.js
@@ -10,6 +10,12 @@ const loggers = new Map()
 const supportedLevels = Object.keys(pino.levels.values)
 supportedLevels.push('silent')
 
+function computeDestination() {
+  const { ROLLUP_WATCH } = process.env
+
+  return ROLLUP_WATCH ? undefined : pino.destination(getLogPath())
+}
+
 /**
  * An array containing logger name and its level
  * @typedef {array<string>} LevelEntry
@@ -122,7 +128,7 @@ exports.getLogger = (name = 'core', lvl) => {
             errorProps: '*'
           }
         },
-        pino.destination(getLogPath())
+        computeDestination()
       )
     }
     logger = name === 'core' ? root : root.child({ name, level })

--- a/renderer/components/Nav/Nav.svelte
+++ b/renderer/components/Nav/Nav.svelte
@@ -90,6 +90,12 @@
         text={$_('playlists')}
         icon="library_music" />
     </li>
+    <li id="to-recent">
+      <Button
+        on:click={() => push('/recent')}
+        text={$_('recent')}
+        icon="history" />
+    </li>
     <li>
       <Button on:click={handleBack} icon="navigate_before" noBorder />
       <Button on:click={handleForward} icon="navigate_next" noBorder />

--- a/renderer/components/Player/Player.svelte
+++ b/renderer/components/Player/Player.svelte
@@ -5,7 +5,7 @@
   import Track from '../Track/Track.svelte'
   import Slider from '../Slider/Slider.svelte'
   import AddToPlaylist from '../AddToPlaylist/AddToPlaylist.svelte'
-  import { toDOMSrc, formatTime } from '../../utils'
+  import { toDOMSrc, formatTime, invoke } from '../../utils'
   import {
     playNext,
     playPrevious,
@@ -15,6 +15,7 @@
     unshuffle,
     shuffle
   } from '../../stores/track-queue'
+  import { appendTracks } from '../../stores/playlists'
 
   export let isPlaylistOpen = false
   let isPlaying
@@ -48,6 +49,7 @@
           player.load()
         }
       } else {
+        invoke('playlists.prependSingleMerge', 151120, current.id)
         src = toDOMSrc(current.path)
         const {
           replaygain_track_gain: trackGain,

--- a/renderer/components/Router/Router.svelte
+++ b/renderer/components/Router/Router.svelte
@@ -18,6 +18,7 @@
   import ArtistDetails from '../../routes/artist/[id].svelte'
   import Playlists from '../../routes/playlist.svelte'
   import PlaylistDetails from '../../routes/playlist/[id].svelte'
+  import Recent from '../../routes/recent.svelte'
   import SearchResults from '../../routes/search/[searched].svelte'
   import Settings from '../../routes/settings.svelte'
 
@@ -30,6 +31,7 @@
     '/artist/:id': ArtistDetails,
     '/playlist': Playlists,
     '/playlist/:id': PlaylistDetails,
+    '/recent': Recent,
     '/search/:searched': SearchResults,
     '/settings': Settings,
     '*': wrap({

--- a/renderer/routes/recent.svelte
+++ b/renderer/routes/recent.svelte
@@ -1,0 +1,110 @@
+<script>
+  import { onMount } from 'svelte'
+  import { fade } from 'svelte/transition'
+  import { _ } from 'svelte-intl'
+  import { replace } from 'svelte-spa-router'
+  import { distinct, filter, map } from 'rxjs/operators'
+  import { Heading, Button, PlaylistTracksTable } from '../components'
+  import { load, changes, removals } from '../stores/playlists'
+  import { add } from '../stores/track-queue'
+  import {
+    invoke,
+    formatTimeLong,
+    fromServerChannel,
+    sumDurations
+  } from '../utils'
+
+  let playlist
+
+  $: playlistId = 151120
+  $: if (!playlist || playlist.id !== playlistId) {
+    loadPlaylist()
+  }
+  $: total = playlist && playlist.trackIds ? playlist.trackIds.length : 0
+
+  async function loadPlaylist() {
+    playlist = await load(playlistId)
+    if (!playlist) {
+      return replace('/recent')
+    }
+  }
+
+  onMount(() => {
+    const changeSub = changes
+      .pipe(
+        map(changed => changed.find(({ id }) => id === playlistId)),
+        filter(n => n),
+        distinct()
+      )
+      .subscribe(async changed => {
+        if (!changed.tracks) {
+          // then load tracks if not yet available
+          playlist = await load(playlist.id)
+        } else {
+          // update now in case of media change
+          playlist = changed
+        }
+      })
+
+    const trackSub = fromServerChannel(`track-changes`).subscribe(changed => {
+      if (
+        playlist &&
+        changed.some(({ id }) => playlist.trackIds.includes(id))
+      ) {
+        loadPlaylist()
+      }
+    })
+
+    return () => {
+      changeSub.unsubscribe()
+      trackSub.unsubscribe()
+    }
+  })
+</script>
+
+<style type="postcss">
+  section {
+    @apply flex flex-row text-left m-4 mt-0;
+  }
+
+  .meta {
+    @apply flex-grow text-xl text-right;
+  }
+
+  .tracks {
+    @apply m-4;
+  }
+</style>
+
+<div in:fade={{ duration: 200 }}>
+  {#if playlist}
+    <Heading
+      title={playlist.name}
+      image={'../images/bantersnaps-nE1K_qO2z38-unsplash.jpg'}
+      imagePosition="center 60%" />
+    <section>
+      <Button
+        on:click={track => add(playlist.tracks, true)}
+        icon="play_arrow"
+        text={$_('play all')} />
+      <Button
+        class="ml-4"
+        on:click={track => add(playlist.tracks)}
+        icon="playlist_add"
+        text={$_('enqueue all')} />
+      <Button
+        class="ml-4"
+        on:click={() => invoke(`playlists.export`, playlist.id)}
+        icon="save_alt"
+        text={$_('export playlist')} />
+      <div class="meta">
+        {$_(total === 1 ? 'a track' : '_ tracks', { total })}
+        {$_('separator')}
+        {formatTimeLong(sumDurations(playlist && playlist.tracks))}
+      </div>
+    </section>
+    <div class="tracks">
+      <PlaylistTracksTable {playlist} />
+    </div>
+  {/if}
+</div>


### PR DESCRIPTION
### What's in there?

Simple implementation of a "recent" feature, built on top of the existing playlist feature.

### How to test?

Play some tracks and see that the newly added "Recent" tap in the main view reflects the most recently played tracks, without duplicates.

### Notes to reviewers

I'm not suggesting this as a final implementation, I wanted to see how easy it would be to introduce this feature by leveraging the playlists feature without creating new models and services. 

I had to change some existing behaviors in order to achieve this:

- the recent feature is a playlist with a specific id, similar to how settings are handled. This is not nice, I know
- when removing the last track from a playlist, the playlist is no longer removed automatically, otherwise the recent playlist would be gone forever. To be honest this makes sense for other playlists too in my opinion. If I created a playlist, why would it be delete automatically when it does not contain any tracks? Maybe I want to add tracks in the future
- the recent playlist works in a slightly different way from other playlists:
  - tracks are automatically added to it when they are played
  - there are no duplicates
  - the tracks are prepended instead of appended, to reflect the "most recent at the top" behavior
- unrelated but I changed logging so it goes to the console when developing, which makes figuring out what's going on much easier
