### PR TITLE
fix(ui): missing tailwind classes, blocked player and blocked tutorial

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,7 +14,6 @@ body:
 
         Please make sure you first searched for existing bugs.
         If you have an idea or some feedback, let's have a [discussion](https://github.com/feugy/melodie/discussions) instead.
-      #render: markdown
     validations:
       required: true
   - type: textarea

--- a/common/ui/src/actions/auto-scrollable/__snapshots__/auto-scrollable.tools.shot
+++ b/common/ui/src/actions/auto-scrollable/__snapshots__/auto-scrollable.tools.shot
@@ -9,7 +9,7 @@ exports[`Toolshot actions/auto-scrollable/auto-scrollable.tools.svelte: Actions/
   </p>
    
   <ol
-    class="svelte-y8i1wy"
+    class="svelte-9aft2y"
     style="--padding: 75px; --margin: -75px;"
   >
     <li

--- a/common/ui/src/components/AddToPlaylist/__snapshots__/AddToPlaylist.tools.shot
+++ b/common/ui/src/components/AddToPlaylist/__snapshots__/AddToPlaylist.tools.shot
@@ -5,13 +5,13 @@ exports[`Toolshot components/AddToPlaylist/AddToPlaylist.tools.svelte: Component
   <span
     aria-expanded="false"
     aria-haspopup="menu"
-    class="wrapper svelte-1x6dshm"
+    class="wrapper svelte-11prmkk"
   >
     <button
-      class="iconOnly svelte-1vd9h50"
+      class="iconOnly svelte-1e4q28k"
     >
       <i
-        class="material-icons svelte-1vd9h50"
+        class="material-icons svelte-1e4q28k"
       >
         library_add
       </i>

--- a/common/ui/src/components/Album/__snapshots__/Album.tools.shot
+++ b/common/ui/src/components/Album/__snapshots__/Album.tools.shot
@@ -4,18 +4,18 @@ exports[`Toolshot components/Album/Album.tools.svelte: Default 1`] = `
 <div>
    
   <span
-    class="svelte-9e8ghi"
+    class="svelte-4r86n"
     role="article"
   >
     <div
-      class="content svelte-9e8ghi"
+      class="content svelte-4r86n"
     >
       <span
-        class="artwork svelte-9e8ghi"
+        class="artwork svelte-4r86n"
       >
         <img
           alt="./cover.jpg"
-          class="h-full w-full rounded-sm svelte-dtt58s"
+          class="h-full w-full rounded-sm svelte-1psk6yi"
           height="256"
           loading="lazy"
           src="./cover.jpg"
@@ -26,15 +26,15 @@ exports[`Toolshot components/Album/Album.tools.svelte: Default 1`] = `
       </span>
        
       <p
-        class="controls svelte-9e8ghi"
+        class="controls svelte-4r86n"
       >
          
         <button
-          class="primary iconOnly large svelte-1vd9h50"
+          class="primary iconOnly large svelte-1e4q28k"
           data-testid="play"
         >
           <i
-            class="material-icons svelte-1vd9h50"
+            class="material-icons svelte-1e4q28k"
           >
             play_arrow
           </i>
@@ -44,11 +44,11 @@ exports[`Toolshot components/Album/Album.tools.svelte: Default 1`] = `
         </button>
          
         <button
-          class="primary iconOnly large svelte-1vd9h50"
+          class="primary iconOnly large svelte-1e4q28k"
           data-testid="enqueue"
         >
           <i
-            class="material-icons svelte-1vd9h50"
+            class="material-icons svelte-1e4q28k"
           >
             playlist_add
           </i>
@@ -60,16 +60,16 @@ exports[`Toolshot components/Album/Album.tools.svelte: Default 1`] = `
     </div>
      
     <header
-      class="svelte-9e8ghi"
+      class="svelte-4r86n"
     >
       <h3
-        class="svelte-9e8ghi"
+        class="svelte-4r86n"
       >
         Diamonds on the inside
       </h3>
        
       <h4
-        class="svelte-1vmk98n"
+        class="svelte-rw2hde"
         slot="details"
       >
         by 
@@ -100,18 +100,18 @@ exports[`Toolshot components/Album/Album.tools.svelte: Many artists 1`] = `
 <div>
    
   <span
-    class="svelte-9e8ghi"
+    class="svelte-4r86n"
     role="article"
   >
     <div
-      class="content svelte-9e8ghi"
+      class="content svelte-4r86n"
     >
       <span
-        class="artwork svelte-9e8ghi"
+        class="artwork svelte-4r86n"
       >
         <img
           alt="./cover.jpg"
-          class="h-full w-full rounded-sm svelte-dtt58s"
+          class="h-full w-full rounded-sm svelte-1psk6yi"
           height="256"
           loading="lazy"
           src="./cover.jpg"
@@ -122,15 +122,15 @@ exports[`Toolshot components/Album/Album.tools.svelte: Many artists 1`] = `
       </span>
        
       <p
-        class="controls svelte-9e8ghi"
+        class="controls svelte-4r86n"
       >
          
         <button
-          class="primary iconOnly large svelte-1vd9h50"
+          class="primary iconOnly large svelte-1e4q28k"
           data-testid="play"
         >
           <i
-            class="material-icons svelte-1vd9h50"
+            class="material-icons svelte-1e4q28k"
           >
             play_arrow
           </i>
@@ -140,11 +140,11 @@ exports[`Toolshot components/Album/Album.tools.svelte: Many artists 1`] = `
         </button>
          
         <button
-          class="primary iconOnly large svelte-1vd9h50"
+          class="primary iconOnly large svelte-1e4q28k"
           data-testid="enqueue"
         >
           <i
-            class="material-icons svelte-1vd9h50"
+            class="material-icons svelte-1e4q28k"
           >
             playlist_add
           </i>
@@ -156,16 +156,16 @@ exports[`Toolshot components/Album/Album.tools.svelte: Many artists 1`] = `
     </div>
      
     <header
-      class="svelte-9e8ghi"
+      class="svelte-4r86n"
     >
       <h3
-        class="svelte-9e8ghi"
+        class="svelte-4r86n"
       >
         Diamonds on the inside
       </h3>
        
       <h4
-        class="svelte-1vmk98n"
+        class="svelte-rw2hde"
         slot="details"
       >
         by 
@@ -212,18 +212,18 @@ exports[`Toolshot components/Album/Album.tools.svelte: No artist 1`] = `
 <div>
    
   <span
-    class="svelte-9e8ghi"
+    class="svelte-4r86n"
     role="article"
   >
     <div
-      class="content svelte-9e8ghi"
+      class="content svelte-4r86n"
     >
       <span
-        class="artwork svelte-9e8ghi"
+        class="artwork svelte-4r86n"
       >
         <img
           alt="./cover.jpg"
-          class="h-full w-full rounded-sm svelte-dtt58s"
+          class="h-full w-full rounded-sm svelte-1psk6yi"
           height="256"
           loading="lazy"
           src="./cover.jpg"
@@ -234,15 +234,15 @@ exports[`Toolshot components/Album/Album.tools.svelte: No artist 1`] = `
       </span>
        
       <p
-        class="controls svelte-9e8ghi"
+        class="controls svelte-4r86n"
       >
          
         <button
-          class="primary iconOnly large svelte-1vd9h50"
+          class="primary iconOnly large svelte-1e4q28k"
           data-testid="play"
         >
           <i
-            class="material-icons svelte-1vd9h50"
+            class="material-icons svelte-1e4q28k"
           >
             play_arrow
           </i>
@@ -252,11 +252,11 @@ exports[`Toolshot components/Album/Album.tools.svelte: No artist 1`] = `
         </button>
          
         <button
-          class="primary iconOnly large svelte-1vd9h50"
+          class="primary iconOnly large svelte-1e4q28k"
           data-testid="enqueue"
         >
           <i
-            class="material-icons svelte-1vd9h50"
+            class="material-icons svelte-1e4q28k"
           >
             playlist_add
           </i>
@@ -268,16 +268,16 @@ exports[`Toolshot components/Album/Album.tools.svelte: No artist 1`] = `
     </div>
      
     <header
-      class="svelte-9e8ghi"
+      class="svelte-4r86n"
     >
       <h3
-        class="svelte-9e8ghi"
+        class="svelte-4r86n"
       >
         Diamonds on the inside
       </h3>
        
       <h4
-        class="svelte-1vmk98n"
+        class="svelte-rw2hde"
         slot="details"
       >
          
@@ -291,27 +291,27 @@ exports[`Toolshot components/Album/Album.tools.svelte: Unknown 1`] = `
 <div>
    
   <span
-    class="svelte-9e8ghi"
+    class="svelte-4r86n"
     role="article"
   >
     <div
-      class="content svelte-9e8ghi"
+      class="content svelte-4r86n"
     >
       <span
-        class="artwork svelte-9e8ghi"
+        class="artwork svelte-4r86n"
       >
         <img
-          class="h-full w-full rounded-sm hidden svelte-dtt58s"
+          class="h-full w-full rounded-sm hidden svelte-1psk6yi"
           height="256"
           loading="lazy"
           width="256"
         />
          
         <span
-          class="h-full w-full svelte-dtt58s rounded-sm"
+          class="h-full w-full svelte-1psk6yi rounded-sm"
         >
           <i
-            class="material-icons svelte-dtt58s"
+            class="material-icons svelte-1psk6yi"
           >
             music_note
           </i>
@@ -320,15 +320,15 @@ exports[`Toolshot components/Album/Album.tools.svelte: Unknown 1`] = `
       </span>
        
       <p
-        class="controls svelte-9e8ghi"
+        class="controls svelte-4r86n"
       >
          
         <button
-          class="primary iconOnly large svelte-1vd9h50"
+          class="primary iconOnly large svelte-1e4q28k"
           data-testid="play"
         >
           <i
-            class="material-icons svelte-1vd9h50"
+            class="material-icons svelte-1e4q28k"
           >
             play_arrow
           </i>
@@ -338,11 +338,11 @@ exports[`Toolshot components/Album/Album.tools.svelte: Unknown 1`] = `
         </button>
          
         <button
-          class="primary iconOnly large svelte-1vd9h50"
+          class="primary iconOnly large svelte-1e4q28k"
           data-testid="enqueue"
         >
           <i
-            class="material-icons svelte-1vd9h50"
+            class="material-icons svelte-1e4q28k"
           >
             playlist_add
           </i>
@@ -354,16 +354,16 @@ exports[`Toolshot components/Album/Album.tools.svelte: Unknown 1`] = `
     </div>
      
     <header
-      class="svelte-9e8ghi"
+      class="svelte-4r86n"
     >
       <h3
-        class="svelte-9e8ghi"
+        class="svelte-4r86n"
       >
         Unknown
       </h3>
        
       <h4
-        class="svelte-1vmk98n"
+        class="svelte-rw2hde"
         slot="details"
       >
         by 

--- a/common/ui/src/components/Annotation/__snapshots__/Annotation.tools.shot
+++ b/common/ui/src/components/Annotation/__snapshots__/Annotation.tools.shot
@@ -3,77 +3,77 @@
 exports[`Toolshot components/Annotation/Annotation.tools.svelte: Above center left 1`] = `
 <span>
   <div
-    class="backdrop svelte-1xmwz8x"
+    class="backdrop svelte-12nprlq"
     style=""
   >
      
     <article
-      class="svelte-1xmwz8x"
+      class="svelte-12nprlq"
     >
       Look! This text looks very interesting
     </article>
   </div>
    
   <div
-    class="test-grid svelte-wewt25"
+    class="test-grid svelte-1wi3uh1"
   >
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       In eu mi bibendum neque egestas congue quisque egestas
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Arcu non odio euismod lacinia at quis risus sed
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Massa tempor nec feugiat nisl
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Sagittis aliquam malesuada bibendum arcu vitae elementum
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Elementum facilisis leo vel fringilla est ullamcorper eget nulla
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Bibendum arcu vitae elementum curabitur vitae nunc sed velit dignissim
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Elit sed vulputate mi sit amet mauris commodo
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Ut enim blandit volutpat maecenas volutpat blandit aliquam etiam erat
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Lorem mollis aliquam ut porttitor leo a diam sollicitudin
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Vitae proin sagittis nisl rhoncus mattis
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Ut morbi tincidunt augue interdum velit euismod in pellentesque
     </div>
@@ -88,77 +88,77 @@ exports[`Toolshot components/Annotation/Annotation.tools.svelte: Above center le
 exports[`Toolshot components/Annotation/Annotation.tools.svelte: Above center right 1`] = `
 <span>
   <div
-    class="backdrop svelte-1xmwz8x"
+    class="backdrop svelte-12nprlq"
     style=""
   >
      
     <article
-      class="svelte-1xmwz8x"
+      class="svelte-12nprlq"
     >
       Look! This text looks very interesting
     </article>
   </div>
    
   <div
-    class="test-grid svelte-wewt25"
+    class="test-grid svelte-1wi3uh1"
   >
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       In eu mi bibendum neque egestas congue quisque egestas
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Arcu non odio euismod lacinia at quis risus sed
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Massa tempor nec feugiat nisl
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Sagittis aliquam malesuada bibendum arcu vitae elementum
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Elementum facilisis leo vel fringilla est ullamcorper eget nulla
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Bibendum arcu vitae elementum curabitur vitae nunc sed velit dignissim
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Elit sed vulputate mi sit amet mauris commodo
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Ut enim blandit volutpat maecenas volutpat blandit aliquam etiam erat
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Lorem mollis aliquam ut porttitor leo a diam sollicitudin
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Vitae proin sagittis nisl rhoncus mattis
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Ut morbi tincidunt augue interdum velit euismod in pellentesque
     </div>
@@ -173,77 +173,77 @@ exports[`Toolshot components/Annotation/Annotation.tools.svelte: Above center ri
 exports[`Toolshot components/Annotation/Annotation.tools.svelte: Above right 1`] = `
 <span>
   <div
-    class="backdrop svelte-1xmwz8x"
+    class="backdrop svelte-12nprlq"
     style=""
   >
      
     <article
-      class="svelte-1xmwz8x"
+      class="svelte-12nprlq"
     >
       Look! This text looks very interesting
     </article>
   </div>
    
   <div
-    class="test-grid svelte-wewt25"
+    class="test-grid svelte-1wi3uh1"
   >
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       In eu mi bibendum neque egestas congue quisque egestas
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Arcu non odio euismod lacinia at quis risus sed
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Massa tempor nec feugiat nisl
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Sagittis aliquam malesuada bibendum arcu vitae elementum
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Elementum facilisis leo vel fringilla est ullamcorper eget nulla
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Bibendum arcu vitae elementum curabitur vitae nunc sed velit dignissim
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Elit sed vulputate mi sit amet mauris commodo
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Ut enim blandit volutpat maecenas volutpat blandit aliquam etiam erat
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Lorem mollis aliquam ut porttitor leo a diam sollicitudin
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Vitae proin sagittis nisl rhoncus mattis
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Ut morbi tincidunt augue interdum velit euismod in pellentesque
     </div>
@@ -258,77 +258,77 @@ exports[`Toolshot components/Annotation/Annotation.tools.svelte: Above right 1`]
 exports[`Toolshot components/Annotation/Annotation.tools.svelte: Anchor not found 1`] = `
 <span>
   <div
-    class="backdrop svelte-1xmwz8x"
+    class="backdrop svelte-12nprlq"
     style=""
   >
      
     <article
-      class="svelte-1xmwz8x"
+      class="svelte-12nprlq"
     >
       Look! This text looks very interesting
     </article>
   </div>
    
   <div
-    class="test-grid svelte-wewt25"
+    class="test-grid svelte-1wi3uh1"
   >
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       In eu mi bibendum neque egestas congue quisque egestas
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Arcu non odio euismod lacinia at quis risus sed
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Massa tempor nec feugiat nisl
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Sagittis aliquam malesuada bibendum arcu vitae elementum
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Elementum facilisis leo vel fringilla est ullamcorper eget nulla
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Bibendum arcu vitae elementum curabitur vitae nunc sed velit dignissim
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Elit sed vulputate mi sit amet mauris commodo
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Ut enim blandit volutpat maecenas volutpat blandit aliquam etiam erat
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Lorem mollis aliquam ut porttitor leo a diam sollicitudin
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Vitae proin sagittis nisl rhoncus mattis
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Ut morbi tincidunt augue interdum velit euismod in pellentesque
     </div>
@@ -343,77 +343,77 @@ exports[`Toolshot components/Annotation/Annotation.tools.svelte: Anchor not foun
 exports[`Toolshot components/Annotation/Annotation.tools.svelte: Bellow center left 1`] = `
 <span>
   <div
-    class="backdrop svelte-1xmwz8x"
+    class="backdrop svelte-12nprlq"
     style=""
   >
      
     <article
-      class="svelte-1xmwz8x"
+      class="svelte-12nprlq"
     >
       Look! This text looks very interesting
     </article>
   </div>
    
   <div
-    class="test-grid svelte-wewt25"
+    class="test-grid svelte-1wi3uh1"
   >
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       In eu mi bibendum neque egestas congue quisque egestas
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Arcu non odio euismod lacinia at quis risus sed
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Massa tempor nec feugiat nisl
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Sagittis aliquam malesuada bibendum arcu vitae elementum
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Elementum facilisis leo vel fringilla est ullamcorper eget nulla
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Bibendum arcu vitae elementum curabitur vitae nunc sed velit dignissim
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Elit sed vulputate mi sit amet mauris commodo
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Ut enim blandit volutpat maecenas volutpat blandit aliquam etiam erat
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Lorem mollis aliquam ut porttitor leo a diam sollicitudin
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Vitae proin sagittis nisl rhoncus mattis
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Ut morbi tincidunt augue interdum velit euismod in pellentesque
     </div>
@@ -428,77 +428,77 @@ exports[`Toolshot components/Annotation/Annotation.tools.svelte: Bellow center l
 exports[`Toolshot components/Annotation/Annotation.tools.svelte: Bellow center right 1`] = `
 <span>
   <div
-    class="backdrop svelte-1xmwz8x"
+    class="backdrop svelte-12nprlq"
     style=""
   >
      
     <article
-      class="svelte-1xmwz8x"
+      class="svelte-12nprlq"
     >
       Look! This text looks very interesting
     </article>
   </div>
    
   <div
-    class="test-grid svelte-wewt25"
+    class="test-grid svelte-1wi3uh1"
   >
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       In eu mi bibendum neque egestas congue quisque egestas
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Arcu non odio euismod lacinia at quis risus sed
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Massa tempor nec feugiat nisl
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Sagittis aliquam malesuada bibendum arcu vitae elementum
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Elementum facilisis leo vel fringilla est ullamcorper eget nulla
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Bibendum arcu vitae elementum curabitur vitae nunc sed velit dignissim
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Elit sed vulputate mi sit amet mauris commodo
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Ut enim blandit volutpat maecenas volutpat blandit aliquam etiam erat
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Lorem mollis aliquam ut porttitor leo a diam sollicitudin
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Vitae proin sagittis nisl rhoncus mattis
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Ut morbi tincidunt augue interdum velit euismod in pellentesque
     </div>
@@ -513,77 +513,77 @@ exports[`Toolshot components/Annotation/Annotation.tools.svelte: Bellow center r
 exports[`Toolshot components/Annotation/Annotation.tools.svelte: Bellow left 1`] = `
 <span>
   <div
-    class="backdrop svelte-1xmwz8x"
+    class="backdrop svelte-12nprlq"
     style=""
   >
      
     <article
-      class="svelte-1xmwz8x"
+      class="svelte-12nprlq"
     >
       Look! This text looks very interesting
     </article>
   </div>
    
   <div
-    class="test-grid svelte-wewt25"
+    class="test-grid svelte-1wi3uh1"
   >
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       In eu mi bibendum neque egestas congue quisque egestas
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Arcu non odio euismod lacinia at quis risus sed
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Massa tempor nec feugiat nisl
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Sagittis aliquam malesuada bibendum arcu vitae elementum
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Elementum facilisis leo vel fringilla est ullamcorper eget nulla
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Bibendum arcu vitae elementum curabitur vitae nunc sed velit dignissim
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Elit sed vulputate mi sit amet mauris commodo
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Ut enim blandit volutpat maecenas volutpat blandit aliquam etiam erat
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Lorem mollis aliquam ut porttitor leo a diam sollicitudin
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Vitae proin sagittis nisl rhoncus mattis
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Ut morbi tincidunt augue interdum velit euismod in pellentesque
     </div>
@@ -598,77 +598,77 @@ exports[`Toolshot components/Annotation/Annotation.tools.svelte: Bellow left 1`]
 exports[`Toolshot components/Annotation/Annotation.tools.svelte: Bellow right 1`] = `
 <span>
   <div
-    class="backdrop svelte-1xmwz8x"
+    class="backdrop svelte-12nprlq"
     style=""
   >
      
     <article
-      class="svelte-1xmwz8x"
+      class="svelte-12nprlq"
     >
       Look! This text looks very interesting
     </article>
   </div>
    
   <div
-    class="test-grid svelte-wewt25"
+    class="test-grid svelte-1wi3uh1"
   >
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       In eu mi bibendum neque egestas congue quisque egestas
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Arcu non odio euismod lacinia at quis risus sed
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Massa tempor nec feugiat nisl
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Sagittis aliquam malesuada bibendum arcu vitae elementum
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Elementum facilisis leo vel fringilla est ullamcorper eget nulla
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Bibendum arcu vitae elementum curabitur vitae nunc sed velit dignissim
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Elit sed vulputate mi sit amet mauris commodo
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Ut enim blandit volutpat maecenas volutpat blandit aliquam etiam erat
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Lorem mollis aliquam ut porttitor leo a diam sollicitudin
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Vitae proin sagittis nisl rhoncus mattis
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Ut morbi tincidunt augue interdum velit euismod in pellentesque
     </div>
@@ -683,77 +683,77 @@ exports[`Toolshot components/Annotation/Annotation.tools.svelte: Bellow right 1`
 exports[`Toolshot components/Annotation/Annotation.tools.svelte: Default 1`] = `
 <span>
   <div
-    class="backdrop svelte-1xmwz8x"
+    class="backdrop svelte-12nprlq"
     style=""
   >
      
     <article
-      class="svelte-1xmwz8x"
+      class="svelte-12nprlq"
     >
       Look! This text looks very interesting
     </article>
   </div>
    
   <div
-    class="test-grid svelte-wewt25"
+    class="test-grid svelte-1wi3uh1"
   >
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       In eu mi bibendum neque egestas congue quisque egestas
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Arcu non odio euismod lacinia at quis risus sed
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Massa tempor nec feugiat nisl
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Sagittis aliquam malesuada bibendum arcu vitae elementum
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Elementum facilisis leo vel fringilla est ullamcorper eget nulla
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Bibendum arcu vitae elementum curabitur vitae nunc sed velit dignissim
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Elit sed vulputate mi sit amet mauris commodo
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Ut enim blandit volutpat maecenas volutpat blandit aliquam etiam erat
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Lorem mollis aliquam ut porttitor leo a diam sollicitudin
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Vitae proin sagittis nisl rhoncus mattis
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Ut morbi tincidunt augue interdum velit euismod in pellentesque
     </div>
@@ -768,77 +768,77 @@ exports[`Toolshot components/Annotation/Annotation.tools.svelte: Default 1`] = `
 exports[`Toolshot components/Annotation/Annotation.tools.svelte: Hidden anchor 1`] = `
 <span>
   <div
-    class="backdrop svelte-1xmwz8x"
+    class="backdrop svelte-12nprlq"
     style=""
   >
      
     <article
-      class="svelte-1xmwz8x"
+      class="svelte-12nprlq"
     >
       Look! This text looks very interesting
     </article>
   </div>
    
   <div
-    class="test-grid svelte-wewt25"
+    class="test-grid svelte-1wi3uh1"
   >
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       In eu mi bibendum neque egestas congue quisque egestas
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Arcu non odio euismod lacinia at quis risus sed
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Massa tempor nec feugiat nisl
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Sagittis aliquam malesuada bibendum arcu vitae elementum
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Elementum facilisis leo vel fringilla est ullamcorper eget nulla
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Bibendum arcu vitae elementum curabitur vitae nunc sed velit dignissim
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Elit sed vulputate mi sit amet mauris commodo
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Ut enim blandit volutpat maecenas volutpat blandit aliquam etiam erat
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Lorem mollis aliquam ut porttitor leo a diam sollicitudin
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Vitae proin sagittis nisl rhoncus mattis
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Ut morbi tincidunt augue interdum velit euismod in pellentesque
     </div>
@@ -853,77 +853,77 @@ exports[`Toolshot components/Annotation/Annotation.tools.svelte: Hidden anchor 1
 exports[`Toolshot components/Annotation/Annotation.tools.svelte: Middle left 1`] = `
 <span>
   <div
-    class="backdrop svelte-1xmwz8x"
+    class="backdrop svelte-12nprlq"
     style=""
   >
      
     <article
-      class="svelte-1xmwz8x"
+      class="svelte-12nprlq"
     >
       Look! This text looks very interesting
     </article>
   </div>
    
   <div
-    class="test-grid svelte-wewt25"
+    class="test-grid svelte-1wi3uh1"
   >
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       In eu mi bibendum neque egestas congue quisque egestas
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Arcu non odio euismod lacinia at quis risus sed
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Massa tempor nec feugiat nisl
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Sagittis aliquam malesuada bibendum arcu vitae elementum
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Elementum facilisis leo vel fringilla est ullamcorper eget nulla
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Bibendum arcu vitae elementum curabitur vitae nunc sed velit dignissim
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Elit sed vulputate mi sit amet mauris commodo
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Ut enim blandit volutpat maecenas volutpat blandit aliquam etiam erat
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Lorem mollis aliquam ut porttitor leo a diam sollicitudin
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Vitae proin sagittis nisl rhoncus mattis
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Ut morbi tincidunt augue interdum velit euismod in pellentesque
     </div>
@@ -938,77 +938,77 @@ exports[`Toolshot components/Annotation/Annotation.tools.svelte: Middle left 1`]
 exports[`Toolshot components/Annotation/Annotation.tools.svelte: Middle right 1`] = `
 <span>
   <div
-    class="backdrop svelte-1xmwz8x"
+    class="backdrop svelte-12nprlq"
     style=""
   >
      
     <article
-      class="svelte-1xmwz8x"
+      class="svelte-12nprlq"
     >
       Look! This text looks very interesting
     </article>
   </div>
    
   <div
-    class="test-grid svelte-wewt25"
+    class="test-grid svelte-1wi3uh1"
   >
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       In eu mi bibendum neque egestas congue quisque egestas
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Arcu non odio euismod lacinia at quis risus sed
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Massa tempor nec feugiat nisl
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Sagittis aliquam malesuada bibendum arcu vitae elementum
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Elementum facilisis leo vel fringilla est ullamcorper eget nulla
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Bibendum arcu vitae elementum curabitur vitae nunc sed velit dignissim
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Elit sed vulputate mi sit amet mauris commodo
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Ut enim blandit volutpat maecenas volutpat blandit aliquam etiam erat
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Lorem mollis aliquam ut porttitor leo a diam sollicitudin
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Vitae proin sagittis nisl rhoncus mattis
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Ut morbi tincidunt augue interdum velit euismod in pellentesque
     </div>
@@ -1023,12 +1023,12 @@ exports[`Toolshot components/Annotation/Annotation.tools.svelte: Middle right 1`
 exports[`Toolshot components/Annotation/Annotation.tools.svelte: Positionned 1`] = `
 <span>
   <div
-    class="backdrop svelte-1xmwz8x"
+    class="backdrop svelte-12nprlq"
     style=""
   >
      
     <article
-      class="svelte-1xmwz8x"
+      class="svelte-12nprlq"
       style="top: 5%; left: 60%;"
     >
       Look! This text looks very interesting
@@ -1036,65 +1036,65 @@ exports[`Toolshot components/Annotation/Annotation.tools.svelte: Positionned 1`]
   </div>
    
   <div
-    class="test-grid svelte-wewt25"
+    class="test-grid svelte-1wi3uh1"
   >
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       In eu mi bibendum neque egestas congue quisque egestas
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Arcu non odio euismod lacinia at quis risus sed
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Massa tempor nec feugiat nisl
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Sagittis aliquam malesuada bibendum arcu vitae elementum
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Elementum facilisis leo vel fringilla est ullamcorper eget nulla
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Bibendum arcu vitae elementum curabitur vitae nunc sed velit dignissim
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Elit sed vulputate mi sit amet mauris commodo
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Ut enim blandit volutpat maecenas volutpat blandit aliquam etiam erat
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Lorem mollis aliquam ut porttitor leo a diam sollicitudin
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Vitae proin sagittis nisl rhoncus mattis
     </div>
     <div
-      class="svelte-wewt25"
+      class="svelte-1wi3uh1"
     >
       Ut morbi tincidunt augue interdum velit euismod in pellentesque
     </div>

--- a/common/ui/src/components/Artist/__snapshots__/Artist.tools.shot
+++ b/common/ui/src/components/Artist/__snapshots__/Artist.tools.shot
@@ -4,18 +4,18 @@ exports[`Toolshot components/Artist/Artist.tools.svelte: Default 1`] = `
 <div>
    
   <span
-    class="svelte-9e8ghi"
+    class="svelte-4r86n"
     role="article"
   >
     <div
-      class="content svelte-9e8ghi"
+      class="content svelte-4r86n"
     >
       <span
-        class="artwork svelte-9e8ghi"
+        class="artwork svelte-4r86n"
       >
         <img
           alt="./avatar.jpg"
-          class="h-full w-full rounded-full svelte-dtt58s"
+          class="h-full w-full rounded-full svelte-1psk6yi"
           height="256"
           loading="lazy"
           src="./avatar.jpg"
@@ -26,15 +26,15 @@ exports[`Toolshot components/Artist/Artist.tools.svelte: Default 1`] = `
       </span>
        
       <p
-        class="controls svelte-9e8ghi"
+        class="controls svelte-4r86n"
       >
          
         <button
-          class="primary iconOnly large svelte-1vd9h50"
+          class="primary iconOnly large svelte-1e4q28k"
           data-testid="play"
         >
           <i
-            class="material-icons svelte-1vd9h50"
+            class="material-icons svelte-1e4q28k"
           >
             play_arrow
           </i>
@@ -44,11 +44,11 @@ exports[`Toolshot components/Artist/Artist.tools.svelte: Default 1`] = `
         </button>
          
         <button
-          class="primary iconOnly large svelte-1vd9h50"
+          class="primary iconOnly large svelte-1e4q28k"
           data-testid="enqueue"
         >
           <i
-            class="material-icons svelte-1vd9h50"
+            class="material-icons svelte-1e4q28k"
           >
             playlist_add
           </i>
@@ -60,16 +60,16 @@ exports[`Toolshot components/Artist/Artist.tools.svelte: Default 1`] = `
     </div>
      
     <header
-      class="svelte-9e8ghi"
+      class="svelte-4r86n"
     >
       <h3
-        class="svelte-9e8ghi"
+        class="svelte-4r86n"
       >
         Foo Fighters
       </h3>
        
       <h4
-        class="svelte-1vmk98n"
+        class="svelte-rw2hde"
         slot="details"
       >
         2 albums
@@ -83,18 +83,18 @@ exports[`Toolshot components/Artist/Artist.tools.svelte: No album 1`] = `
 <div>
    
   <span
-    class="svelte-9e8ghi"
+    class="svelte-4r86n"
     role="article"
   >
     <div
-      class="content svelte-9e8ghi"
+      class="content svelte-4r86n"
     >
       <span
-        class="artwork svelte-9e8ghi"
+        class="artwork svelte-4r86n"
       >
         <img
           alt="./avatar.jpg"
-          class="h-full w-full rounded-full svelte-dtt58s"
+          class="h-full w-full rounded-full svelte-1psk6yi"
           height="256"
           loading="lazy"
           src="./avatar.jpg"
@@ -105,15 +105,15 @@ exports[`Toolshot components/Artist/Artist.tools.svelte: No album 1`] = `
       </span>
        
       <p
-        class="controls svelte-9e8ghi"
+        class="controls svelte-4r86n"
       >
          
         <button
-          class="primary iconOnly large svelte-1vd9h50"
+          class="primary iconOnly large svelte-1e4q28k"
           data-testid="play"
         >
           <i
-            class="material-icons svelte-1vd9h50"
+            class="material-icons svelte-1e4q28k"
           >
             play_arrow
           </i>
@@ -123,11 +123,11 @@ exports[`Toolshot components/Artist/Artist.tools.svelte: No album 1`] = `
         </button>
          
         <button
-          class="primary iconOnly large svelte-1vd9h50"
+          class="primary iconOnly large svelte-1e4q28k"
           data-testid="enqueue"
         >
           <i
-            class="material-icons svelte-1vd9h50"
+            class="material-icons svelte-1e4q28k"
           >
             playlist_add
           </i>
@@ -139,16 +139,16 @@ exports[`Toolshot components/Artist/Artist.tools.svelte: No album 1`] = `
     </div>
      
     <header
-      class="svelte-9e8ghi"
+      class="svelte-4r86n"
     >
       <h3
-        class="svelte-9e8ghi"
+        class="svelte-4r86n"
       >
         Foo Fighters
       </h3>
        
       <h4
-        class="svelte-1vmk98n"
+        class="svelte-rw2hde"
         slot="details"
       />
     </header>
@@ -160,27 +160,27 @@ exports[`Toolshot components/Artist/Artist.tools.svelte: Unknown 1`] = `
 <div>
    
   <span
-    class="svelte-9e8ghi"
+    class="svelte-4r86n"
     role="article"
   >
     <div
-      class="content svelte-9e8ghi"
+      class="content svelte-4r86n"
     >
       <span
-        class="artwork svelte-9e8ghi"
+        class="artwork svelte-4r86n"
       >
         <img
-          class="h-full w-full rounded-full hidden svelte-dtt58s"
+          class="h-full w-full rounded-full hidden svelte-1psk6yi"
           height="256"
           loading="lazy"
           width="256"
         />
          
         <span
-          class="h-full w-full svelte-dtt58s rounded-full"
+          class="h-full w-full svelte-1psk6yi rounded-full"
         >
           <i
-            class="material-icons svelte-dtt58s"
+            class="material-icons svelte-1psk6yi"
           >
             person
           </i>
@@ -189,15 +189,15 @@ exports[`Toolshot components/Artist/Artist.tools.svelte: Unknown 1`] = `
       </span>
        
       <p
-        class="controls svelte-9e8ghi"
+        class="controls svelte-4r86n"
       >
          
         <button
-          class="primary iconOnly large svelte-1vd9h50"
+          class="primary iconOnly large svelte-1e4q28k"
           data-testid="play"
         >
           <i
-            class="material-icons svelte-1vd9h50"
+            class="material-icons svelte-1e4q28k"
           >
             play_arrow
           </i>
@@ -207,11 +207,11 @@ exports[`Toolshot components/Artist/Artist.tools.svelte: Unknown 1`] = `
         </button>
          
         <button
-          class="primary iconOnly large svelte-1vd9h50"
+          class="primary iconOnly large svelte-1e4q28k"
           data-testid="enqueue"
         >
           <i
-            class="material-icons svelte-1vd9h50"
+            class="material-icons svelte-1e4q28k"
           >
             playlist_add
           </i>
@@ -223,16 +223,16 @@ exports[`Toolshot components/Artist/Artist.tools.svelte: Unknown 1`] = `
     </div>
      
     <header
-      class="svelte-9e8ghi"
+      class="svelte-4r86n"
     >
       <h3
-        class="svelte-9e8ghi"
+        class="svelte-4r86n"
       >
         Unknown
       </h3>
        
       <h4
-        class="svelte-1vmk98n"
+        class="svelte-rw2hde"
         slot="details"
       >
         2 albums

--- a/common/ui/src/components/BroadcastButton/__snapshots__/BroadcastButton.tools.shot
+++ b/common/ui/src/components/BroadcastButton/__snapshots__/BroadcastButton.tools.shot
@@ -3,13 +3,13 @@
 exports[`Toolshot components/BroadcastButton/BroadcastButton.tools.svelte: Components/Broadcast button 1`] = `
 <span>
   <span
-    class="button svelte-cykzim"
+    class="button svelte-d6nb7m"
   >
     <button
-      class="iconOnly noBorder svelte-1vd9h50"
+      class="iconOnly noBorder svelte-1e4q28k"
     >
       <i
-        class="material-icons svelte-1vd9h50"
+        class="material-icons svelte-1e4q28k"
       >
         wifi_off
       </i>

--- a/common/ui/src/components/Button/__snapshots__/Button.tools.shot
+++ b/common/ui/src/components/Button/__snapshots__/Button.tools.shot
@@ -3,7 +3,7 @@
 exports[`Toolshot components/Button/Button.tools.svelte: Default 1`] = `
 <span>
   <button
-    class="svelte-1vd9h50"
+    class="svelte-1e4q28k"
   >
      
     <span>
@@ -18,10 +18,10 @@ exports[`Toolshot components/Button/Button.tools.svelte: Default 1`] = `
 exports[`Toolshot components/Button/Button.tools.svelte: Large icon 1`] = `
 <span>
   <button
-    class="iconOnly large svelte-1vd9h50"
+    class="iconOnly large svelte-1e4q28k"
   >
     <i
-      class="material-icons svelte-1vd9h50"
+      class="material-icons svelte-1e4q28k"
     >
       play_arrow
     </i>
@@ -35,10 +35,10 @@ exports[`Toolshot components/Button/Button.tools.svelte: Large icon 1`] = `
 exports[`Toolshot components/Button/Button.tools.svelte: Large text and icon 1`] = `
 <span>
   <button
-    class="large svelte-1vd9h50"
+    class="large svelte-1e4q28k"
   >
     <i
-      class="material-icons svelte-1vd9h50"
+      class="material-icons svelte-1e4q28k"
     >
       person
     </i>
@@ -55,7 +55,7 @@ exports[`Toolshot components/Button/Button.tools.svelte: Large text and icon 1`]
 exports[`Toolshot components/Button/Button.tools.svelte: Primary 1`] = `
 <span>
   <button
-    class="primary svelte-1vd9h50"
+    class="primary svelte-1e4q28k"
   >
      
     <span>
@@ -70,10 +70,10 @@ exports[`Toolshot components/Button/Button.tools.svelte: Primary 1`] = `
 exports[`Toolshot components/Button/Button.tools.svelte: Primary icon 1`] = `
 <span>
   <button
-    class="primary iconOnly svelte-1vd9h50"
+    class="primary iconOnly svelte-1e4q28k"
   >
     <i
-      class="material-icons svelte-1vd9h50"
+      class="material-icons svelte-1e4q28k"
     >
       volume_up
     </i>
@@ -87,10 +87,10 @@ exports[`Toolshot components/Button/Button.tools.svelte: Primary icon 1`] = `
 exports[`Toolshot components/Button/Button.tools.svelte: Primary with badge 1`] = `
 <span>
   <button
-    class="primary svelte-1vd9h50"
+    class="primary svelte-1e4q28k"
   >
     <i
-      class="material-icons svelte-1vd9h50"
+      class="material-icons svelte-1e4q28k"
     >
       face
     </i>
@@ -101,7 +101,7 @@ exports[`Toolshot components/Button/Button.tools.svelte: Primary with badge 1`] 
      
      
     <div
-      class="badge svelte-1vd9h50 halo"
+      class="badge svelte-1e4q28k halo"
     >
       5
     </div>
@@ -112,10 +112,10 @@ exports[`Toolshot components/Button/Button.tools.svelte: Primary with badge 1`] 
 exports[`Toolshot components/Button/Button.tools.svelte: Text and icon 1`] = `
 <span>
   <button
-    class="svelte-1vd9h50"
+    class="svelte-1e4q28k"
   >
     <i
-      class="material-icons svelte-1vd9h50"
+      class="material-icons svelte-1e4q28k"
     >
       face
     </i>
@@ -132,10 +132,10 @@ exports[`Toolshot components/Button/Button.tools.svelte: Text and icon 1`] = `
 exports[`Toolshot components/Button/Button.tools.svelte: With badge 1`] = `
 <span>
   <button
-    class="svelte-1vd9h50"
+    class="svelte-1e4q28k"
   >
     <i
-      class="material-icons svelte-1vd9h50"
+      class="material-icons svelte-1e4q28k"
     >
       face
     </i>
@@ -146,7 +146,7 @@ exports[`Toolshot components/Button/Button.tools.svelte: With badge 1`] = `
      
      
     <div
-      class="badge svelte-1vd9h50 halo"
+      class="badge svelte-1e4q28k halo"
     >
       23
     </div>
@@ -157,10 +157,10 @@ exports[`Toolshot components/Button/Button.tools.svelte: With badge 1`] = `
 exports[`Toolshot components/Button/Button.tools.svelte: With badge limit 1`] = `
 <span>
   <button
-    class="svelte-1vd9h50"
+    class="svelte-1e4q28k"
   >
     <i
-      class="material-icons svelte-1vd9h50"
+      class="material-icons svelte-1e4q28k"
     >
       warning
     </i>
@@ -171,7 +171,7 @@ exports[`Toolshot components/Button/Button.tools.svelte: With badge limit 1`] = 
      
      
     <div
-      class="badge svelte-1vd9h50 halo"
+      class="badge svelte-1e4q28k halo"
     >
       999+
     </div>

--- a/common/ui/src/components/DisksList/__snapshots__/DisksList.tools.shot
+++ b/common/ui/src/components/DisksList/__snapshots__/DisksList.tools.shot
@@ -7,70 +7,70 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
    
    
   <table
-    class=" svelte-14yn4jg"
+    class=" svelte-1uzdiz4"
   >
     <thead
-      class="svelte-14yn4jg"
+      class="svelte-1uzdiz4"
     >
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <th
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           #
         </th>
          
         <th
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Track
         </th>
          
         <th
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Artist
         </th>
          
         <th
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Album
         </th>
          
         <th
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           Duration
         </th>
          
         <th
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         />
       </tr>
     </thead>
      
     <tbody
-      class="svelte-14yn4jg"
+      class="svelte-1uzdiz4"
     >
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           1
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           American Money
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -90,7 +90,7 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -102,24 +102,24 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           5:32
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -135,22 +135,22 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           2
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Fantaisie Sign
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -170,7 +170,7 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -182,24 +182,24 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           3:35
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -219,7 +219,7 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
   
   
   <h3
-    class="svelte-11p7ayw"
+    class="svelte-w4sfb"
   >
     Disk #1
   </h3>
@@ -227,70 +227,70 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
    
    
   <table
-    class=" svelte-14yn4jg"
+    class=" svelte-1uzdiz4"
   >
     <thead
-      class="svelte-14yn4jg"
+      class="svelte-1uzdiz4"
     >
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <th
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           #
         </th>
          
         <th
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Track
         </th>
          
         <th
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Artist
         </th>
          
         <th
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Album
         </th>
          
         <th
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           Duration
         </th>
          
         <th
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         />
       </tr>
     </thead>
      
     <tbody
-      class="svelte-14yn4jg"
+      class="svelte-1uzdiz4"
     >
       <tr
-        class="svelte-14yn4jg current"
+        class="svelte-1uzdiz4 current"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           2
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Vitamin A
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -310,7 +310,7 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -322,24 +322,24 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           4:41
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -355,22 +355,22 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           3
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Don't Bother None
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -390,7 +390,7 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -402,24 +402,24 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           3:45
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -435,22 +435,22 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           4
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Want it All Back
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -470,7 +470,7 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -482,24 +482,24 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           3:51
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -515,22 +515,22 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           5
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Bindy
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -550,7 +550,7 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -562,24 +562,24 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           0:15
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -595,22 +595,22 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           6
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           You Make Me Coo
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -630,7 +630,7 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -642,24 +642,24 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           3:14
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -675,22 +675,22 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           7
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Vitamin C
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -710,7 +710,7 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -722,24 +722,24 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           5:24
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -755,22 +755,22 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           8
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Gateway
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -790,7 +790,7 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -802,24 +802,24 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           0:16
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -835,22 +835,22 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           9
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Forever Broke
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -870,7 +870,7 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -882,24 +882,24 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           1:36
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -919,7 +919,7 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
   
   
   <h3
-    class="svelte-11p7ayw"
+    class="svelte-w4sfb"
   >
     Disk #2
   </h3>
@@ -927,70 +927,70 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
    
    
   <table
-    class=" svelte-14yn4jg"
+    class=" svelte-1uzdiz4"
   >
     <thead
-      class="svelte-14yn4jg"
+      class="svelte-1uzdiz4"
     >
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <th
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           #
         </th>
          
         <th
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Track
         </th>
          
         <th
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Artist
         </th>
          
         <th
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Album
         </th>
          
         <th
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           Duration
         </th>
          
         <th
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         />
       </tr>
     </thead>
      
     <tbody
-      class="svelte-14yn4jg"
+      class="svelte-1uzdiz4"
     >
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           2
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Cats on Mars
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1010,7 +1010,7 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1022,24 +1022,24 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           0:07
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -1055,22 +1055,22 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           3
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           LIVE in Baghdad
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1090,7 +1090,7 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1102,24 +1102,24 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           2:59
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -1135,22 +1135,22 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           4
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Vitamin B
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1170,7 +1170,7 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1182,24 +1182,24 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           4:06
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -1215,22 +1215,22 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           5
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Green Bird
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1250,7 +1250,7 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1262,24 +1262,24 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           2:33
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -1295,22 +1295,22 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           6
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           ELM
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1330,7 +1330,7 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1342,24 +1342,24 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           6:55
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -1375,22 +1375,22 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           7
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           The Singing Sea
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1410,7 +1410,7 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1422,24 +1422,24 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           6:41
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -1455,22 +1455,22 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           8
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           The Egg and You!
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1490,7 +1490,7 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1502,24 +1502,24 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           4:47
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -1535,22 +1535,22 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           9
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Power of Kungfu Remix
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1570,7 +1570,7 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1582,24 +1582,24 @@ exports[`Toolshot components/DisksList/DisksList.tools.svelte: Components/Disks 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           2:22
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>

--- a/common/ui/src/components/Dropdown/__snapshots__/Dropdown.tools.shot
+++ b/common/ui/src/components/Dropdown/__snapshots__/Dropdown.tools.shot
@@ -14,14 +14,14 @@ exports[`Toolshot components/Dropdown/Dropdown.tools.svelte: Custom button optio
     <span
       aria-expanded="false"
       aria-haspopup="menu"
-      class="wrapper svelte-1x6dshm"
+      class="wrapper svelte-11prmkk"
     >
       <button
         align="text-right"
-        class="primary svelte-1vd9h50"
+        class="primary svelte-1e4q28k"
       >
         <i
-          class="material-icons svelte-1vd9h50"
+          class="material-icons svelte-1e4q28k"
         >
           person
         </i>
@@ -31,7 +31,7 @@ exports[`Toolshot components/Dropdown/Dropdown.tools.svelte: Custom button optio
         </span>
          
         <i
-          class="material-icons arrow svelte-1x6dshm"
+          class="material-icons arrow svelte-11prmkk"
         >
           arrow_drop_down
         </i>
@@ -125,10 +125,10 @@ exports[`Toolshot components/Dropdown/Dropdown.tools.svelte: Custom option 1`] =
     <span
       aria-expanded="false"
       aria-haspopup="menu"
-      class="wrapper svelte-1x6dshm"
+      class="wrapper svelte-11prmkk"
     >
       <button
-        class="svelte-1vd9h50"
+        class="svelte-1e4q28k"
       >
          
         <span>
@@ -136,7 +136,7 @@ exports[`Toolshot components/Dropdown/Dropdown.tools.svelte: Custom option 1`] =
         </span>
          
         <i
-          class="material-icons arrow svelte-1x6dshm"
+          class="material-icons arrow svelte-11prmkk"
         >
           arrow_drop_down
         </i>
@@ -230,10 +230,10 @@ exports[`Toolshot components/Dropdown/Dropdown.tools.svelte: Default 1`] = `
     <span
       aria-expanded="false"
       aria-haspopup="menu"
-      class="wrapper svelte-1x6dshm"
+      class="wrapper svelte-11prmkk"
     >
       <button
-        class="svelte-1vd9h50"
+        class="svelte-1e4q28k"
       >
          
         <span>
@@ -241,7 +241,7 @@ exports[`Toolshot components/Dropdown/Dropdown.tools.svelte: Default 1`] = `
         </span>
          
         <i
-          class="material-icons arrow svelte-1x6dshm"
+          class="material-icons arrow svelte-11prmkk"
         >
           arrow_drop_down
         </i>
@@ -335,14 +335,14 @@ exports[`Toolshot components/Dropdown/Dropdown.tools.svelte: Icon only with rela
     <span
       aria-expanded="false"
       aria-haspopup="menu"
-      class="wrapper svelte-1x6dshm"
+      class="wrapper svelte-11prmkk"
     >
       <button
-        class="iconOnly svelte-1vd9h50"
+        class="iconOnly svelte-1e4q28k"
         parentposition="relative"
       >
         <i
-          class="material-icons svelte-1vd9h50"
+          class="material-icons svelte-1e4q28k"
         >
           more_vert
         </i>
@@ -438,14 +438,14 @@ exports[`Toolshot components/Dropdown/Dropdown.tools.svelte: Independent text an
     <span
       aria-expanded="false"
       aria-haspopup="menu"
-      class="wrapper svelte-1x6dshm"
+      class="wrapper svelte-11prmkk"
     >
       <button
         align="text-left"
-        class="svelte-1vd9h50"
+        class="svelte-1e4q28k"
       >
         <i
-          class="material-icons svelte-1vd9h50"
+          class="material-icons svelte-1e4q28k"
         >
           settings
         </i>
@@ -455,7 +455,7 @@ exports[`Toolshot components/Dropdown/Dropdown.tools.svelte: Independent text an
         </span>
          
         <i
-          class="material-icons arrow svelte-1x6dshm"
+          class="material-icons arrow svelte-11prmkk"
         >
           arrow_drop_down
         </i>
@@ -549,10 +549,10 @@ exports[`Toolshot components/Dropdown/Dropdown.tools.svelte: Simple array 1`] = 
     <span
       aria-expanded="false"
       aria-haspopup="menu"
-      class="wrapper svelte-1x6dshm"
+      class="wrapper svelte-11prmkk"
     >
       <button
-        class="svelte-1vd9h50"
+        class="svelte-1e4q28k"
       >
          
         <span>
@@ -560,7 +560,7 @@ exports[`Toolshot components/Dropdown/Dropdown.tools.svelte: Simple array 1`] = 
         </span>
          
         <i
-          class="material-icons arrow svelte-1x6dshm"
+          class="material-icons arrow svelte-11prmkk"
         >
           arrow_drop_down
         </i>

--- a/common/ui/src/components/ExpandableList/__snapshots__/ExpandableList.tools.shot
+++ b/common/ui/src/components/ExpandableList/__snapshots__/ExpandableList.tools.shot
@@ -3,34 +3,34 @@
 exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Albums 1`] = `
 <div>
   <span
-    class="undefined albums svelte-uiewq8"
+    class="undefined albums svelte-1kobtom"
   >
     <h3
-      class="svelte-uiewq8"
+      class="svelte-1kobtom"
     >
       5 albums
     </h3>
      
     <ul
-      class="svelte-uiewq8"
+      class="svelte-1kobtom"
     >
       <li
-        class="svelte-uiewq8"
+        class="svelte-1kobtom"
       >
          
         <span
-          class="svelte-9e8ghi"
+          class="svelte-4r86n"
           role="article"
         >
           <div
-            class="content svelte-9e8ghi"
+            class="content svelte-4r86n"
           >
             <span
-              class="artwork svelte-9e8ghi"
+              class="artwork svelte-4r86n"
             >
               <img
                 alt="./cover.jpg"
-                class="h-full w-full rounded-sm svelte-dtt58s"
+                class="h-full w-full rounded-sm svelte-1psk6yi"
                 height="256"
                 loading="lazy"
                 src="./cover.jpg"
@@ -41,15 +41,15 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Albums 
             </span>
              
             <p
-              class="controls svelte-9e8ghi"
+              class="controls svelte-4r86n"
             >
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="play"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   play_arrow
                 </i>
@@ -59,11 +59,11 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Albums 
               </button>
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="enqueue"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   playlist_add
                 </i>
@@ -75,16 +75,16 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Albums 
           </div>
            
           <header
-            class="svelte-9e8ghi"
+            class="svelte-4r86n"
           >
             <h3
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
             >
               Diamonds on the inside
             </h3>
              
             <h4
-              class="svelte-1vmk98n"
+              class="svelte-rw2hde"
               slot="details"
             >
               by 
@@ -111,22 +111,22 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Albums 
          
       </li>
       <li
-        class="svelte-uiewq8"
+        class="svelte-1kobtom"
       >
          
         <span
-          class="svelte-9e8ghi"
+          class="svelte-4r86n"
           role="article"
         >
           <div
-            class="content svelte-9e8ghi"
+            class="content svelte-4r86n"
           >
             <span
-              class="artwork svelte-9e8ghi"
+              class="artwork svelte-4r86n"
             >
               <img
                 alt="./cover.jpg"
-                class="h-full w-full rounded-sm svelte-dtt58s"
+                class="h-full w-full rounded-sm svelte-1psk6yi"
                 height="256"
                 loading="lazy"
                 src="./cover.jpg"
@@ -137,15 +137,15 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Albums 
             </span>
              
             <p
-              class="controls svelte-9e8ghi"
+              class="controls svelte-4r86n"
             >
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="play"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   play_arrow
                 </i>
@@ -155,11 +155,11 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Albums 
               </button>
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="enqueue"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   playlist_add
                 </i>
@@ -171,16 +171,16 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Albums 
           </div>
            
           <header
-            class="svelte-9e8ghi"
+            class="svelte-4r86n"
           >
             <h3
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
             >
               Diamonds on the inside
             </h3>
              
             <h4
-              class="svelte-1vmk98n"
+              class="svelte-rw2hde"
               slot="details"
             >
               by 
@@ -207,22 +207,22 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Albums 
          
       </li>
       <li
-        class="svelte-uiewq8"
+        class="svelte-1kobtom"
       >
          
         <span
-          class="svelte-9e8ghi"
+          class="svelte-4r86n"
           role="article"
         >
           <div
-            class="content svelte-9e8ghi"
+            class="content svelte-4r86n"
           >
             <span
-              class="artwork svelte-9e8ghi"
+              class="artwork svelte-4r86n"
             >
               <img
                 alt="./cover.jpg"
-                class="h-full w-full rounded-sm svelte-dtt58s"
+                class="h-full w-full rounded-sm svelte-1psk6yi"
                 height="256"
                 loading="lazy"
                 src="./cover.jpg"
@@ -233,15 +233,15 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Albums 
             </span>
              
             <p
-              class="controls svelte-9e8ghi"
+              class="controls svelte-4r86n"
             >
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="play"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   play_arrow
                 </i>
@@ -251,11 +251,11 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Albums 
               </button>
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="enqueue"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   playlist_add
                 </i>
@@ -267,16 +267,16 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Albums 
           </div>
            
           <header
-            class="svelte-9e8ghi"
+            class="svelte-4r86n"
           >
             <h3
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
             >
               Diamonds on the inside
             </h3>
              
             <h4
-              class="svelte-1vmk98n"
+              class="svelte-rw2hde"
               slot="details"
             >
               by 
@@ -303,22 +303,22 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Albums 
          
       </li>
       <li
-        class="svelte-uiewq8"
+        class="svelte-1kobtom"
       >
          
         <span
-          class="svelte-9e8ghi"
+          class="svelte-4r86n"
           role="article"
         >
           <div
-            class="content svelte-9e8ghi"
+            class="content svelte-4r86n"
           >
             <span
-              class="artwork svelte-9e8ghi"
+              class="artwork svelte-4r86n"
             >
               <img
                 alt="./cover.jpg"
-                class="h-full w-full rounded-sm svelte-dtt58s"
+                class="h-full w-full rounded-sm svelte-1psk6yi"
                 height="256"
                 loading="lazy"
                 src="./cover.jpg"
@@ -329,15 +329,15 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Albums 
             </span>
              
             <p
-              class="controls svelte-9e8ghi"
+              class="controls svelte-4r86n"
             >
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="play"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   play_arrow
                 </i>
@@ -347,11 +347,11 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Albums 
               </button>
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="enqueue"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   playlist_add
                 </i>
@@ -363,16 +363,16 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Albums 
           </div>
            
           <header
-            class="svelte-9e8ghi"
+            class="svelte-4r86n"
           >
             <h3
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
             >
               Diamonds on the inside
             </h3>
              
             <h4
-              class="svelte-1vmk98n"
+              class="svelte-rw2hde"
               slot="details"
             >
               by 
@@ -399,22 +399,22 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Albums 
          
       </li>
       <li
-        class="svelte-uiewq8"
+        class="svelte-1kobtom"
       >
          
         <span
-          class="svelte-9e8ghi"
+          class="svelte-4r86n"
           role="article"
         >
           <div
-            class="content svelte-9e8ghi"
+            class="content svelte-4r86n"
           >
             <span
-              class="artwork svelte-9e8ghi"
+              class="artwork svelte-4r86n"
             >
               <img
                 alt="./cover.jpg"
-                class="h-full w-full rounded-sm svelte-dtt58s"
+                class="h-full w-full rounded-sm svelte-1psk6yi"
                 height="256"
                 loading="lazy"
                 src="./cover.jpg"
@@ -425,15 +425,15 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Albums 
             </span>
              
             <p
-              class="controls svelte-9e8ghi"
+              class="controls svelte-4r86n"
             >
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="play"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   play_arrow
                 </i>
@@ -443,11 +443,11 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Albums 
               </button>
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="enqueue"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   playlist_add
                 </i>
@@ -459,16 +459,16 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Albums 
           </div>
            
           <header
-            class="svelte-9e8ghi"
+            class="svelte-4r86n"
           >
             <h3
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
             >
               Diamonds on the inside
             </h3>
              
             <h4
-              class="svelte-1vmk98n"
+              class="svelte-rw2hde"
               slot="details"
             >
               by 
@@ -510,34 +510,34 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Albums 
 exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Artists 1`] = `
 <div>
   <span
-    class="undefined artists svelte-uiewq8"
+    class="undefined artists svelte-1kobtom"
   >
     <h3
-      class="svelte-uiewq8"
+      class="svelte-1kobtom"
     >
       5 artists
     </h3>
      
     <ul
-      class="svelte-uiewq8"
+      class="svelte-1kobtom"
     >
       <li
-        class="svelte-uiewq8"
+        class="svelte-1kobtom"
       >
          
         <span
-          class="svelte-9e8ghi"
+          class="svelte-4r86n"
           role="article"
         >
           <div
-            class="content svelte-9e8ghi"
+            class="content svelte-4r86n"
           >
             <span
-              class="artwork svelte-9e8ghi"
+              class="artwork svelte-4r86n"
             >
               <img
                 alt="./avatar.jpg"
-                class="h-full w-full rounded-full svelte-dtt58s"
+                class="h-full w-full rounded-full svelte-1psk6yi"
                 height="256"
                 loading="lazy"
                 src="./avatar.jpg"
@@ -548,15 +548,15 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Artists
             </span>
              
             <p
-              class="controls svelte-9e8ghi"
+              class="controls svelte-4r86n"
             >
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="play"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   play_arrow
                 </i>
@@ -566,11 +566,11 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Artists
               </button>
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="enqueue"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   playlist_add
                 </i>
@@ -582,16 +582,16 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Artists
           </div>
            
           <header
-            class="svelte-9e8ghi"
+            class="svelte-4r86n"
           >
             <h3
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
             >
               Foo Fighters
             </h3>
              
             <h4
-              class="svelte-1vmk98n"
+              class="svelte-rw2hde"
               slot="details"
             >
               2 albums
@@ -601,22 +601,22 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Artists
          
       </li>
       <li
-        class="svelte-uiewq8"
+        class="svelte-1kobtom"
       >
          
         <span
-          class="svelte-9e8ghi"
+          class="svelte-4r86n"
           role="article"
         >
           <div
-            class="content svelte-9e8ghi"
+            class="content svelte-4r86n"
           >
             <span
-              class="artwork svelte-9e8ghi"
+              class="artwork svelte-4r86n"
             >
               <img
                 alt="./avatar.jpg"
-                class="h-full w-full rounded-full svelte-dtt58s"
+                class="h-full w-full rounded-full svelte-1psk6yi"
                 height="256"
                 loading="lazy"
                 src="./avatar.jpg"
@@ -627,15 +627,15 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Artists
             </span>
              
             <p
-              class="controls svelte-9e8ghi"
+              class="controls svelte-4r86n"
             >
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="play"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   play_arrow
                 </i>
@@ -645,11 +645,11 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Artists
               </button>
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="enqueue"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   playlist_add
                 </i>
@@ -661,16 +661,16 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Artists
           </div>
            
           <header
-            class="svelte-9e8ghi"
+            class="svelte-4r86n"
           >
             <h3
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
             >
               Foo Fighters
             </h3>
              
             <h4
-              class="svelte-1vmk98n"
+              class="svelte-rw2hde"
               slot="details"
             >
               2 albums
@@ -680,22 +680,22 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Artists
          
       </li>
       <li
-        class="svelte-uiewq8"
+        class="svelte-1kobtom"
       >
          
         <span
-          class="svelte-9e8ghi"
+          class="svelte-4r86n"
           role="article"
         >
           <div
-            class="content svelte-9e8ghi"
+            class="content svelte-4r86n"
           >
             <span
-              class="artwork svelte-9e8ghi"
+              class="artwork svelte-4r86n"
             >
               <img
                 alt="./avatar.jpg"
-                class="h-full w-full rounded-full svelte-dtt58s"
+                class="h-full w-full rounded-full svelte-1psk6yi"
                 height="256"
                 loading="lazy"
                 src="./avatar.jpg"
@@ -706,15 +706,15 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Artists
             </span>
              
             <p
-              class="controls svelte-9e8ghi"
+              class="controls svelte-4r86n"
             >
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="play"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   play_arrow
                 </i>
@@ -724,11 +724,11 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Artists
               </button>
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="enqueue"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   playlist_add
                 </i>
@@ -740,16 +740,16 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Artists
           </div>
            
           <header
-            class="svelte-9e8ghi"
+            class="svelte-4r86n"
           >
             <h3
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
             >
               Foo Fighters
             </h3>
              
             <h4
-              class="svelte-1vmk98n"
+              class="svelte-rw2hde"
               slot="details"
             >
               2 albums
@@ -759,22 +759,22 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Artists
          
       </li>
       <li
-        class="svelte-uiewq8"
+        class="svelte-1kobtom"
       >
          
         <span
-          class="svelte-9e8ghi"
+          class="svelte-4r86n"
           role="article"
         >
           <div
-            class="content svelte-9e8ghi"
+            class="content svelte-4r86n"
           >
             <span
-              class="artwork svelte-9e8ghi"
+              class="artwork svelte-4r86n"
             >
               <img
                 alt="./avatar.jpg"
-                class="h-full w-full rounded-full svelte-dtt58s"
+                class="h-full w-full rounded-full svelte-1psk6yi"
                 height="256"
                 loading="lazy"
                 src="./avatar.jpg"
@@ -785,15 +785,15 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Artists
             </span>
              
             <p
-              class="controls svelte-9e8ghi"
+              class="controls svelte-4r86n"
             >
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="play"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   play_arrow
                 </i>
@@ -803,11 +803,11 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Artists
               </button>
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="enqueue"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   playlist_add
                 </i>
@@ -819,16 +819,16 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Artists
           </div>
            
           <header
-            class="svelte-9e8ghi"
+            class="svelte-4r86n"
           >
             <h3
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
             >
               Foo Fighters
             </h3>
              
             <h4
-              class="svelte-1vmk98n"
+              class="svelte-rw2hde"
               slot="details"
             >
               2 albums
@@ -838,22 +838,22 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Artists
          
       </li>
       <li
-        class="svelte-uiewq8"
+        class="svelte-1kobtom"
       >
          
         <span
-          class="svelte-9e8ghi"
+          class="svelte-4r86n"
           role="article"
         >
           <div
-            class="content svelte-9e8ghi"
+            class="content svelte-4r86n"
           >
             <span
-              class="artwork svelte-9e8ghi"
+              class="artwork svelte-4r86n"
             >
               <img
                 alt="./avatar.jpg"
-                class="h-full w-full rounded-full svelte-dtt58s"
+                class="h-full w-full rounded-full svelte-1psk6yi"
                 height="256"
                 loading="lazy"
                 src="./avatar.jpg"
@@ -864,15 +864,15 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Artists
             </span>
              
             <p
-              class="controls svelte-9e8ghi"
+              class="controls svelte-4r86n"
             >
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="play"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   play_arrow
                 </i>
@@ -882,11 +882,11 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Artists
               </button>
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="enqueue"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   playlist_add
                 </i>
@@ -898,16 +898,16 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Artists
           </div>
            
           <header
-            class="svelte-9e8ghi"
+            class="svelte-4r86n"
           >
             <h3
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
             >
               Foo Fighters
             </h3>
              
             <h4
-              class="svelte-1vmk98n"
+              class="svelte-rw2hde"
               slot="details"
             >
               2 albums
@@ -932,22 +932,22 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Artists
 exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Tracks 1`] = `
 <div>
   <span
-    class="undefined tracks svelte-uiewq8"
+    class="undefined tracks svelte-1kobtom"
   >
     <h3
-      class="svelte-uiewq8"
+      class="svelte-1kobtom"
     >
       5 tracks
     </h3>
      
     <ul
-      class="svelte-uiewq8"
+      class="svelte-1kobtom"
     >
       <li
-        class="svelte-uiewq8"
+        class="svelte-1kobtom"
       >
         <div
-          class="undefined root svelte-1wnrcpi"
+          class="undefined root svelte-30dtyc"
         >
           <a
             class="flex-none"
@@ -955,7 +955,7 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Tracks 
           >
             <img
               alt="./cover.jpg"
-              class="h-16 w-16 text-xs actionable rounded-sm svelte-dtt58s"
+              class="h-16 w-16 text-xs actionable rounded-sm svelte-1psk6yi"
               height="256"
               loading="lazy"
               src="./cover.jpg"
@@ -966,10 +966,10 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Tracks 
           </a>
            
           <div
-            class="track svelte-1wnrcpi"
+            class="track svelte-30dtyc"
           >
             <span
-              class="title svelte-1wnrcpi"
+              class="title svelte-30dtyc"
             >
               Mama got a girlfriend
             </span>
@@ -989,13 +989,13 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Tracks 
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -1011,10 +1011,10 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Tracks 
          
       </li>
       <li
-        class="svelte-uiewq8"
+        class="svelte-1kobtom"
       >
         <div
-          class="undefined root svelte-1wnrcpi"
+          class="undefined root svelte-30dtyc"
         >
           <a
             class="flex-none"
@@ -1022,7 +1022,7 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Tracks 
           >
             <img
               alt="./cover.jpg"
-              class="h-16 w-16 text-xs actionable rounded-sm svelte-dtt58s"
+              class="h-16 w-16 text-xs actionable rounded-sm svelte-1psk6yi"
               height="256"
               loading="lazy"
               src="./cover.jpg"
@@ -1033,10 +1033,10 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Tracks 
           </a>
            
           <div
-            class="track svelte-1wnrcpi"
+            class="track svelte-30dtyc"
           >
             <span
-              class="title svelte-1wnrcpi"
+              class="title svelte-30dtyc"
             >
               Mama got a girlfriend
             </span>
@@ -1056,13 +1056,13 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Tracks 
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -1078,10 +1078,10 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Tracks 
          
       </li>
       <li
-        class="svelte-uiewq8"
+        class="svelte-1kobtom"
       >
         <div
-          class="undefined root svelte-1wnrcpi"
+          class="undefined root svelte-30dtyc"
         >
           <a
             class="flex-none"
@@ -1089,7 +1089,7 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Tracks 
           >
             <img
               alt="./cover.jpg"
-              class="h-16 w-16 text-xs actionable rounded-sm svelte-dtt58s"
+              class="h-16 w-16 text-xs actionable rounded-sm svelte-1psk6yi"
               height="256"
               loading="lazy"
               src="./cover.jpg"
@@ -1100,10 +1100,10 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Tracks 
           </a>
            
           <div
-            class="track svelte-1wnrcpi"
+            class="track svelte-30dtyc"
           >
             <span
-              class="title svelte-1wnrcpi"
+              class="title svelte-30dtyc"
             >
               Mama got a girlfriend
             </span>
@@ -1123,13 +1123,13 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Tracks 
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -1145,10 +1145,10 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Tracks 
          
       </li>
       <li
-        class="svelte-uiewq8"
+        class="svelte-1kobtom"
       >
         <div
-          class="undefined root svelte-1wnrcpi"
+          class="undefined root svelte-30dtyc"
         >
           <a
             class="flex-none"
@@ -1156,7 +1156,7 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Tracks 
           >
             <img
               alt="./cover.jpg"
-              class="h-16 w-16 text-xs actionable rounded-sm svelte-dtt58s"
+              class="h-16 w-16 text-xs actionable rounded-sm svelte-1psk6yi"
               height="256"
               loading="lazy"
               src="./cover.jpg"
@@ -1167,10 +1167,10 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Tracks 
           </a>
            
           <div
-            class="track svelte-1wnrcpi"
+            class="track svelte-30dtyc"
           >
             <span
-              class="title svelte-1wnrcpi"
+              class="title svelte-30dtyc"
             >
               Mama got a girlfriend
             </span>
@@ -1190,13 +1190,13 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Tracks 
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -1212,10 +1212,10 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Tracks 
          
       </li>
       <li
-        class="svelte-uiewq8"
+        class="svelte-1kobtom"
       >
         <div
-          class="undefined root svelte-1wnrcpi"
+          class="undefined root svelte-30dtyc"
         >
           <a
             class="flex-none"
@@ -1223,7 +1223,7 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Tracks 
           >
             <img
               alt="./cover.jpg"
-              class="h-16 w-16 text-xs actionable rounded-sm svelte-dtt58s"
+              class="h-16 w-16 text-xs actionable rounded-sm svelte-1psk6yi"
               height="256"
               loading="lazy"
               src="./cover.jpg"
@@ -1234,10 +1234,10 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Tracks 
           </a>
            
           <div
-            class="track svelte-1wnrcpi"
+            class="track svelte-30dtyc"
           >
             <span
-              class="title svelte-1wnrcpi"
+              class="title svelte-30dtyc"
             >
               Mama got a girlfriend
             </span>
@@ -1257,13 +1257,13 @@ exports[`Toolshot components/ExpandableList/ExpandableList.tools.svelte: Tracks 
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>

--- a/common/ui/src/components/Heading/__snapshots__/Heading.tools.shot
+++ b/common/ui/src/components/Heading/__snapshots__/Heading.tools.shot
@@ -3,11 +3,11 @@
 exports[`Toolshot components/Heading/Heading.tools.svelte: Components/Heading 1`] = `
 <section>
   <header
-    class=" svelte-8800qh"
+    class=" svelte-t58ezf"
     style="--image: url(./images/valentino-funghi-MEcxLZ8ENV8-unsplash.jpg); --shade-color: rgba(0, 0, 0, 0.7); --bgPosition: center;"
   >
     <h1
-      class="svelte-8800qh"
+      class="svelte-t58ezf"
     >
       70 albums
     </h1>

--- a/common/ui/src/components/Image/__snapshots__/Image.tools.shot
+++ b/common/ui/src/components/Image/__snapshots__/Image.tools.shot
@@ -4,7 +4,7 @@ exports[`Toolshot components/Image/Image.tools.svelte: Broken 1`] = `
 <span>
   <img
     alt="./unknown.jpg"
-    class="w-64 h-64 inline-block rounded-sm svelte-dtt58s"
+    class="w-64 h-64 inline-block rounded-sm svelte-1psk6yi"
     height="256"
     loading="lazy"
     src="./unknown.jpg"
@@ -23,17 +23,17 @@ exports[`Toolshot components/Image/Image.tools.svelte: Broken rounded 1`] = `
 <span>
   <img
     alt=""
-    class="w-64 h-64 inline-block rounded-full hidden svelte-dtt58s"
+    class="w-64 h-64 inline-block rounded-full hidden svelte-1psk6yi"
     height="256"
     loading="lazy"
     width="256"
   />
    
   <span
-    class="w-64 h-64 inline-block svelte-dtt58s rounded-full"
+    class="w-64 h-64 inline-block svelte-1psk6yi rounded-full"
   >
     <i
-      class="material-icons svelte-dtt58s"
+      class="material-icons svelte-1psk6yi"
     >
       person
     </i>
@@ -50,7 +50,7 @@ exports[`Toolshot components/Image/Image.tools.svelte: Default 1`] = `
 <span>
   <img
     alt="./cover.jpg"
-    class="w-64 h-64 inline-block rounded-sm svelte-dtt58s"
+    class="w-64 h-64 inline-block rounded-sm svelte-1psk6yi"
     height="256"
     loading="lazy"
     src="./cover.jpg"
@@ -69,7 +69,7 @@ exports[`Toolshot components/Image/Image.tools.svelte: Rouded 1`] = `
 <span>
   <img
     alt="./avatar.jpg"
-    class="w-64 h-64 inline-block rounded-full svelte-dtt58s"
+    class="w-64 h-64 inline-block rounded-full svelte-1psk6yi"
     height="256"
     loading="lazy"
     src="./avatar.jpg"
@@ -88,7 +88,7 @@ exports[`Toolshot components/Image/Image.tools.svelte: With escaped path 1`] = `
 <span>
   <img
     alt="./# Films/cover.jpg"
-    class="w-64 h-64 inline-block rounded-sm svelte-dtt58s"
+    class="w-64 h-64 inline-block rounded-sm svelte-1psk6yi"
     height="256"
     loading="lazy"
     src="./%23 Films/cover.jpg"

--- a/common/ui/src/components/ImageUploader/__snapshots__/ImageUploader.tools.shot
+++ b/common/ui/src/components/ImageUploader/__snapshots__/ImageUploader.tools.shot
@@ -3,20 +3,20 @@
 exports[`Toolshot components/ImageUploader/ImageUploader.tools.svelte: Components/Image Uploader 1`] = `
 <span>
   <span
-    class="h-64 w-64 inline-block actionable svelte-11tygyi"
+    class="h-64 w-64 inline-block actionable svelte-15abie0"
   >
     <img
-      class="w-full h-full rounded-sm hidden svelte-dtt58s"
+      class="w-full h-full rounded-sm hidden svelte-1psk6yi"
       height="256"
       loading="lazy"
       width="256"
     />
      
     <span
-      class="w-full h-full svelte-dtt58s rounded-sm"
+      class="w-full h-full svelte-1psk6yi rounded-sm"
     >
       <i
-        class="material-icons svelte-dtt58s"
+        class="material-icons svelte-1psk6yi"
       >
         add_box
       </i>
@@ -24,7 +24,7 @@ exports[`Toolshot components/ImageUploader/ImageUploader.tools.svelte: Component
     
      
     <input
-      class="svelte-11tygyi"
+      class="svelte-15abie0"
       type="file"
     />
   </span>

--- a/common/ui/src/components/Player/Player.svelte
+++ b/common/ui/src/components/Player/Player.svelte
@@ -96,7 +96,6 @@
 
   function handleError() {
     isPlaying = false
-    isLoading = true
     const save = src
     src = null
     setTimeout(() => (src = save), 100)

--- a/common/ui/src/components/Player/Player.test.js
+++ b/common/ui/src/components/Player/Player.test.js
@@ -297,7 +297,7 @@ describe('Player component', () => {
     await audio.dispatchEvent(new Event('error'))
 
     expect(screen.queryByText('pause')).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'play_arrow' })).toBeDisabled()
+    expect(screen.queryByRole('button', { name: 'play_arrow' })).toBeEnabled()
     expect(get(current)).toBeUndefined()
 
     await audio.dispatchEvent(new Event('loadeddata'))

--- a/common/ui/src/components/Player/__snapshots__/Player.tools.shot
+++ b/common/ui/src/components/Player/__snapshots__/Player.tools.shot
@@ -3,36 +3,36 @@
 exports[`Toolshot components/Player/Player.tools.svelte: Empty 1`] = `
 <span>
   <div
-    class="root svelte-1wzurh7"
+    class="root svelte-14oe44p"
   >
     <audio
       autoplay=""
-      class="svelte-1wzurh7"
+      class="svelte-14oe44p"
       data-testid="audio"
     />
     <div
-      class="content svelte-1wzurh7"
+      class="content svelte-14oe44p"
     >
       <span
-        class="current svelte-1wzurh7"
+        class="current svelte-14oe44p"
       />
        
       <div
-        class="player svelte-1wzurh7"
+        class="player svelte-14oe44p"
       >
         <span
-          class="controls svelte-1wzurh7"
+          class="controls svelte-14oe44p"
         >
           
            
           <span
-            class="svelte-5wf0h"
+            class="svelte-1y2tggl"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 shuffle
               </i>
@@ -43,10 +43,10 @@ exports[`Toolshot components/Player/Player.tools.svelte: Empty 1`] = `
           </span>
            
           <button
-            class="iconOnly noBorder svelte-1vd9h50"
+            class="iconOnly noBorder svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               skip_previous
             </i>
@@ -56,10 +56,10 @@ exports[`Toolshot components/Player/Player.tools.svelte: Empty 1`] = `
           </button>
            
           <button
-            class="iconOnly large svelte-1vd9h50"
+            class="iconOnly large svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               play_arrow
             </i>
@@ -69,10 +69,10 @@ exports[`Toolshot components/Player/Player.tools.svelte: Empty 1`] = `
           </button>
            
           <button
-            class="iconOnly noBorder svelte-1vd9h50"
+            class="iconOnly noBorder svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               skip_next
             </i>
@@ -82,13 +82,13 @@ exports[`Toolshot components/Player/Player.tools.svelte: Empty 1`] = `
           </button>
            
           <span
-            class="svelte-5wf0h"
+            class="svelte-1y2tggl"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 repeat
               </i>
@@ -101,36 +101,36 @@ exports[`Toolshot components/Player/Player.tools.svelte: Empty 1`] = `
         </span>
          
         <div
-          class="svelte-fkspjj"
+          class="svelte-1k6r2xh"
         >
           <span
-            class="svelte-fkspjj"
+            class="svelte-1k6r2xh"
           >
             0:00
           </span>
            
           <div
-            class="wrapper w-full svelte-1gmj9k4"
+            class="wrapper w-full svelte-flvs0m"
           >
             <input
-              class="w-full svelte-1gmj9k4"
+              class="w-full svelte-flvs0m"
               max="0"
               min="0"
               type="range"
             />
              
             <div
-              class="sliderTrack svelte-1gmj9k4"
+              class="sliderTrack svelte-flvs0m"
             >
               <span
-                class="progress svelte-1gmj9k4"
+                class="progress svelte-flvs0m"
                 style="right:100%"
               />
             </div>
           </div>
            
           <span
-            class="svelte-fkspjj"
+            class="svelte-1k6r2xh"
           >
             0:00
           </span>
@@ -138,29 +138,29 @@ exports[`Toolshot components/Player/Player.tools.svelte: Empty 1`] = `
       </div>
        
       <span
-        class="volume svelte-1wzurh7"
+        class="volume svelte-14oe44p"
       >
         <div
-          class="svelte-186fmtk"
+          class="svelte-1edewqm"
         >
           <span
-            class="volume-slider svelte-186fmtk"
+            class="volume-slider svelte-1edewqm"
           >
             <div
-              class="wrapper w-full svelte-1gmj9k4"
+              class="wrapper w-full svelte-flvs0m"
             >
               <input
-                class="w-full svelte-1gmj9k4"
+                class="w-full svelte-flvs0m"
                 max="100"
                 min="0"
                 type="range"
               />
                
               <div
-                class="sliderTrack svelte-1gmj9k4"
+                class="sliderTrack svelte-flvs0m"
               >
                 <span
-                  class="progress svelte-1gmj9k4"
+                  class="progress svelte-flvs0m"
                   style="right:0%"
                 />
               </div>
@@ -168,10 +168,10 @@ exports[`Toolshot components/Player/Player.tools.svelte: Empty 1`] = `
           </span>
            
           <button
-            class="iconOnly noBorder svelte-1vd9h50"
+            class="iconOnly noBorder svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               volume_up
             </i>
@@ -189,22 +189,22 @@ exports[`Toolshot components/Player/Player.tools.svelte: Empty 1`] = `
 exports[`Toolshot components/Player/Player.tools.svelte: With track list 1`] = `
 <span>
   <div
-    class="root svelte-1wzurh7"
+    class="root svelte-14oe44p"
   >
     <audio
       autoplay=""
-      class="svelte-1wzurh7"
+      class="svelte-14oe44p"
       data-testid="audio"
       src="./no-duration.mp3"
     />
     <div
-      class="content svelte-1wzurh7"
+      class="content svelte-14oe44p"
     >
       <span
-        class="current svelte-1wzurh7"
+        class="current svelte-14oe44p"
       >
         <div
-          class="undefined root svelte-1wnrcpi"
+          class="undefined root svelte-30dtyc"
         >
           <a
             class="flex-none"
@@ -212,7 +212,7 @@ exports[`Toolshot components/Player/Player.tools.svelte: With track list 1`] = `
           >
             <img
               alt="./# Films/cover.jpg"
-              class="h-16 w-16 text-xs actionable rounded-sm svelte-dtt58s"
+              class="h-16 w-16 text-xs actionable rounded-sm svelte-1psk6yi"
               height="256"
               loading="lazy"
               src="./%23 Films/cover.jpg"
@@ -223,10 +223,10 @@ exports[`Toolshot components/Player/Player.tools.svelte: With track list 1`] = `
           </a>
            
           <div
-            class="track svelte-1wnrcpi"
+            class="track svelte-30dtyc"
           >
             <span
-              class="title svelte-1wnrcpi"
+              class="title svelte-30dtyc"
             >
               file 1
             </span>
@@ -247,22 +247,22 @@ exports[`Toolshot components/Player/Player.tools.svelte: With track list 1`] = `
       </span>
        
       <div
-        class="player svelte-1wzurh7"
+        class="player svelte-14oe44p"
       >
         <span
-          class="controls svelte-1wzurh7"
+          class="controls svelte-14oe44p"
         >
           <span>
             <span
               aria-expanded="false"
               aria-haspopup="menu"
-              class="wrapper svelte-1x6dshm"
+              class="wrapper svelte-11prmkk"
             >
               <button
-                class="iconOnly noBorder svelte-1vd9h50"
+                class="iconOnly noBorder svelte-1e4q28k"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   library_add
                 </i>
@@ -278,13 +278,13 @@ exports[`Toolshot components/Player/Player.tools.svelte: With track list 1`] = `
           
            
           <span
-            class="svelte-5wf0h"
+            class="svelte-1y2tggl"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 shuffle
               </i>
@@ -295,11 +295,11 @@ exports[`Toolshot components/Player/Player.tools.svelte: With track list 1`] = `
           </span>
            
           <button
-            class="iconOnly noBorder svelte-1vd9h50"
+            class="iconOnly noBorder svelte-1e4q28k"
             disabled=""
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               skip_previous
             </i>
@@ -309,11 +309,11 @@ exports[`Toolshot components/Player/Player.tools.svelte: With track list 1`] = `
           </button>
            
           <button
-            class="iconOnly large svelte-1vd9h50"
+            class="iconOnly large svelte-1e4q28k"
             disabled=""
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               play_arrow
             </i>
@@ -323,11 +323,11 @@ exports[`Toolshot components/Player/Player.tools.svelte: With track list 1`] = `
           </button>
            
           <button
-            class="iconOnly noBorder svelte-1vd9h50"
+            class="iconOnly noBorder svelte-1e4q28k"
             disabled=""
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               skip_next
             </i>
@@ -337,13 +337,13 @@ exports[`Toolshot components/Player/Player.tools.svelte: With track list 1`] = `
           </button>
            
           <span
-            class="svelte-5wf0h"
+            class="svelte-1y2tggl"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 repeat
               </i>
@@ -354,10 +354,10 @@ exports[`Toolshot components/Player/Player.tools.svelte: With track list 1`] = `
           </span>
            
           <button
-            class="invisible iconOnly noBorder svelte-1vd9h50"
+            class="invisible iconOnly noBorder svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               favorite_border
             </i>
@@ -368,36 +368,36 @@ exports[`Toolshot components/Player/Player.tools.svelte: With track list 1`] = `
         </span>
          
         <div
-          class="svelte-fkspjj"
+          class="svelte-1k6r2xh"
         >
           <span
-            class="svelte-fkspjj"
+            class="svelte-1k6r2xh"
           >
             0:00
           </span>
            
           <div
-            class="wrapper w-full svelte-1gmj9k4"
+            class="wrapper w-full svelte-flvs0m"
           >
             <input
-              class="w-full svelte-1gmj9k4"
+              class="w-full svelte-flvs0m"
               max="0"
               min="0"
               type="range"
             />
              
             <div
-              class="sliderTrack svelte-1gmj9k4"
+              class="sliderTrack svelte-flvs0m"
             >
               <span
-                class="progress svelte-1gmj9k4"
+                class="progress svelte-flvs0m"
                 style="right:100%"
               />
             </div>
           </div>
            
           <span
-            class="svelte-fkspjj"
+            class="svelte-1k6r2xh"
           >
             0:00
           </span>
@@ -405,29 +405,29 @@ exports[`Toolshot components/Player/Player.tools.svelte: With track list 1`] = `
       </div>
        
       <span
-        class="volume svelte-1wzurh7"
+        class="volume svelte-14oe44p"
       >
         <div
-          class="svelte-186fmtk"
+          class="svelte-1edewqm"
         >
           <span
-            class="volume-slider svelte-186fmtk"
+            class="volume-slider svelte-1edewqm"
           >
             <div
-              class="wrapper w-full svelte-1gmj9k4"
+              class="wrapper w-full svelte-flvs0m"
             >
               <input
-                class="w-full svelte-1gmj9k4"
+                class="w-full svelte-flvs0m"
                 max="100"
                 min="0"
                 type="range"
               />
                
               <div
-                class="sliderTrack svelte-1gmj9k4"
+                class="sliderTrack svelte-flvs0m"
               >
                 <span
-                  class="progress svelte-1gmj9k4"
+                  class="progress svelte-flvs0m"
                   style="right:0%"
                 />
               </div>
@@ -435,10 +435,10 @@ exports[`Toolshot components/Player/Player.tools.svelte: With track list 1`] = `
           </span>
            
           <button
-            class="iconOnly noBorder svelte-1vd9h50"
+            class="iconOnly noBorder svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               volume_up
             </i>

--- a/common/ui/src/components/Playlist/__snapshots__/Playlist.tools.shot
+++ b/common/ui/src/components/Playlist/__snapshots__/Playlist.tools.shot
@@ -4,26 +4,26 @@ exports[`Toolshot components/Playlist/Playlist.tools.svelte: Default 1`] = `
 <div>
    
   <span
-    class="svelte-9e8ghi overlay"
+    class="svelte-4r86n overlay"
     role="article"
   >
     <div
-      class="content svelte-9e8ghi"
+      class="content svelte-4r86n"
     >
       <span
-        class="artwork svelte-9e8ghi"
+        class="artwork svelte-4r86n"
       />
        
       <p
-        class="controls svelte-9e8ghi"
+        class="controls svelte-4r86n"
       >
          
         <button
-          class="primary iconOnly large svelte-1vd9h50"
+          class="primary iconOnly large svelte-1e4q28k"
           data-testid="play"
         >
           <i
-            class="material-icons svelte-1vd9h50"
+            class="material-icons svelte-1e4q28k"
           >
             play_arrow
           </i>
@@ -33,11 +33,11 @@ exports[`Toolshot components/Playlist/Playlist.tools.svelte: Default 1`] = `
         </button>
          
         <button
-          class="primary iconOnly large svelte-1vd9h50"
+          class="primary iconOnly large svelte-1e4q28k"
           data-testid="enqueue"
         >
           <i
-            class="material-icons svelte-1vd9h50"
+            class="material-icons svelte-1e4q28k"
           >
             playlist_add
           </i>
@@ -49,10 +49,10 @@ exports[`Toolshot components/Playlist/Playlist.tools.svelte: Default 1`] = `
     </div>
      
     <header
-      class="svelte-9e8ghi"
+      class="svelte-4r86n"
     >
       <h3
-        class="svelte-9e8ghi"
+        class="svelte-4r86n"
       >
         My favourites
       </h3>
@@ -71,26 +71,26 @@ exports[`Toolshot components/Playlist/Playlist.tools.svelte: Single track 1`] = 
 <div>
    
   <span
-    class="svelte-9e8ghi overlay"
+    class="svelte-4r86n overlay"
     role="article"
   >
     <div
-      class="content svelte-9e8ghi"
+      class="content svelte-4r86n"
     >
       <span
-        class="artwork svelte-9e8ghi"
+        class="artwork svelte-4r86n"
       />
        
       <p
-        class="controls svelte-9e8ghi"
+        class="controls svelte-4r86n"
       >
          
         <button
-          class="primary iconOnly large svelte-1vd9h50"
+          class="primary iconOnly large svelte-1e4q28k"
           data-testid="play"
         >
           <i
-            class="material-icons svelte-1vd9h50"
+            class="material-icons svelte-1e4q28k"
           >
             play_arrow
           </i>
@@ -100,11 +100,11 @@ exports[`Toolshot components/Playlist/Playlist.tools.svelte: Single track 1`] = 
         </button>
          
         <button
-          class="primary iconOnly large svelte-1vd9h50"
+          class="primary iconOnly large svelte-1e4q28k"
           data-testid="enqueue"
         >
           <i
-            class="material-icons svelte-1vd9h50"
+            class="material-icons svelte-1e4q28k"
           >
             playlist_add
           </i>
@@ -116,10 +116,10 @@ exports[`Toolshot components/Playlist/Playlist.tools.svelte: Single track 1`] = 
     </div>
      
     <header
-      class="svelte-9e8ghi"
+      class="svelte-4r86n"
     >
       <h3
-        class="svelte-9e8ghi"
+        class="svelte-4r86n"
       >
         My favourites
       </h3>

--- a/common/ui/src/components/PlaylistTracksTable/__snapshots__/PlaylistTracksTable.tools.shot
+++ b/common/ui/src/components/PlaylistTracksTable/__snapshots__/PlaylistTracksTable.tools.shot
@@ -5,84 +5,84 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
    
    
   <table
-    class="svelte-1qu5p5x"
+    class="svelte-1s1441n"
   >
     <thead
-      class="svelte-1qu5p5x"
+      class="svelte-1s1441n"
     >
       <tr
-        class="svelte-1qu5p5x"
+        class="svelte-1s1441n"
       >
         <th
-          class="svelte-1qu5p5x"
+          class="svelte-1s1441n"
         >
           #
         </th>
          
         <th
-          class="col-span-5 svelte-1qu5p5x"
+          class="col-span-5 svelte-1s1441n"
         >
           Track
         </th>
          
         <th
-          class="col-span-1 svelte-1qu5p5x"
+          class="col-span-1 svelte-1s1441n"
         >
           Duration
         </th>
          
         <th
-          class="col-span-4 svelte-1qu5p5x"
+          class="col-span-4 svelte-1s1441n"
         >
           Album
         </th>
          
         <th
-          class="svelte-1qu5p5x"
+          class="svelte-1s1441n"
         />
       </tr>
     </thead>
      
     <tbody
-      class="svelte-1qu5p5x"
+      class="svelte-1s1441n"
     >
       <ol>
         <li
-          class="svelte-qra3ls"
+          class="svelte-w3rzzq"
           draggable="true"
         >
           <tr
-            class="svelte-1qu5p5x"
+            class="svelte-1s1441n"
             slot="item"
           >
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               1
             </td>
              
             <td
-              class="col-span-6 svelte-1qu5p5x"
+              class="col-span-6 svelte-1s1441n"
             >
               <div
-                class="undefined root svelte-1wnrcpi"
+                class="undefined root svelte-30dtyc"
               >
                 <a
                   class="flex-none"
                   href="#/album/1"
                 >
                   <img
-                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                     height="256"
                     loading="lazy"
                     width="256"
                   />
                    
                   <span
-                    class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                    class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                   >
                     <i
-                      class="material-icons svelte-dtt58s"
+                      class="material-icons svelte-1psk6yi"
                     >
                       music_note
                     </i>
@@ -91,10 +91,10 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </a>
                  
                 <div
-                  class="track svelte-1wnrcpi"
+                  class="track svelte-30dtyc"
                 >
                   <span
-                    class="title svelte-1wnrcpi"
+                    class="title svelte-30dtyc"
                   >
                     American Money
                   </span>
@@ -119,7 +119,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </div>
                  
                 <div
-                  class="duration svelte-1wnrcpi"
+                  class="duration svelte-30dtyc"
                 >
                   5:32
                 </div>
@@ -128,7 +128,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="col-span-4 svelte-1qu5p5x"
+              class="col-span-4 svelte-1s1441n"
             >
               <a
                 class="underlined"
@@ -140,18 +140,18 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -168,41 +168,41 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
            
         </li>
         <li
-          class="svelte-qra3ls"
+          class="svelte-w3rzzq"
           draggable="true"
         >
           <tr
-            class="svelte-1qu5p5x"
+            class="svelte-1s1441n"
             slot="item"
           >
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               2
             </td>
              
             <td
-              class="col-span-6 svelte-1qu5p5x"
+              class="col-span-6 svelte-1s1441n"
             >
               <div
-                class="undefined root svelte-1wnrcpi"
+                class="undefined root svelte-30dtyc"
               >
                 <a
                   class="flex-none"
                   href="#/album/1"
                 >
                   <img
-                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                     height="256"
                     loading="lazy"
                     width="256"
                   />
                    
                   <span
-                    class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                    class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                   >
                     <i
-                      class="material-icons svelte-dtt58s"
+                      class="material-icons svelte-1psk6yi"
                     >
                       music_note
                     </i>
@@ -211,10 +211,10 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </a>
                  
                 <div
-                  class="track svelte-1wnrcpi"
+                  class="track svelte-30dtyc"
                 >
                   <span
-                    class="title svelte-1wnrcpi"
+                    class="title svelte-30dtyc"
                   >
                     Fantaisie Sign
                   </span>
@@ -239,7 +239,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </div>
                  
                 <div
-                  class="duration svelte-1wnrcpi"
+                  class="duration svelte-30dtyc"
                 >
                   3:35
                 </div>
@@ -248,7 +248,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="col-span-4 svelte-1qu5p5x"
+              class="col-span-4 svelte-1s1441n"
             >
               <a
                 class="underlined"
@@ -260,18 +260,18 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -288,41 +288,41 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
            
         </li>
         <li
-          class="svelte-qra3ls"
+          class="svelte-w3rzzq"
           draggable="true"
         >
           <tr
-            class="svelte-1qu5p5x"
+            class="svelte-1s1441n"
             slot="item"
           >
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               3
             </td>
              
             <td
-              class="col-span-6 svelte-1qu5p5x"
+              class="col-span-6 svelte-1s1441n"
             >
               <div
-                class="undefined root svelte-1wnrcpi"
+                class="undefined root svelte-30dtyc"
               >
                 <a
                   class="flex-none"
                   href="#/album/1"
                 >
                   <img
-                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                     height="256"
                     loading="lazy"
                     width="256"
                   />
                    
                   <span
-                    class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                    class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                   >
                     <i
-                      class="material-icons svelte-dtt58s"
+                      class="material-icons svelte-1psk6yi"
                     >
                       music_note
                     </i>
@@ -331,10 +331,10 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </a>
                  
                 <div
-                  class="track svelte-1wnrcpi"
+                  class="track svelte-30dtyc"
                 >
                   <span
-                    class="title svelte-1wnrcpi"
+                    class="title svelte-30dtyc"
                   >
                     Don't Bother None
                   </span>
@@ -359,7 +359,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </div>
                  
                 <div
-                  class="duration svelte-1wnrcpi"
+                  class="duration svelte-30dtyc"
                 >
                   3:45
                 </div>
@@ -368,7 +368,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="col-span-4 svelte-1qu5p5x"
+              class="col-span-4 svelte-1s1441n"
             >
               <a
                 class="underlined"
@@ -380,18 +380,18 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -408,41 +408,41 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
            
         </li>
         <li
-          class="svelte-qra3ls"
+          class="svelte-w3rzzq"
           draggable="true"
         >
           <tr
-            class="svelte-1qu5p5x"
+            class="svelte-1s1441n"
             slot="item"
           >
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               4
             </td>
              
             <td
-              class="col-span-6 svelte-1qu5p5x"
+              class="col-span-6 svelte-1s1441n"
             >
               <div
-                class="undefined root svelte-1wnrcpi"
+                class="undefined root svelte-30dtyc"
               >
                 <a
                   class="flex-none"
                   href="#/album/1"
                 >
                   <img
-                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                     height="256"
                     loading="lazy"
                     width="256"
                   />
                    
                   <span
-                    class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                    class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                   >
                     <i
-                      class="material-icons svelte-dtt58s"
+                      class="material-icons svelte-1psk6yi"
                     >
                       music_note
                     </i>
@@ -451,10 +451,10 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </a>
                  
                 <div
-                  class="track svelte-1wnrcpi"
+                  class="track svelte-30dtyc"
                 >
                   <span
-                    class="title svelte-1wnrcpi"
+                    class="title svelte-30dtyc"
                   >
                     Vitamin A
                   </span>
@@ -479,7 +479,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </div>
                  
                 <div
-                  class="duration svelte-1wnrcpi"
+                  class="duration svelte-30dtyc"
                 >
                   4:41
                 </div>
@@ -488,7 +488,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="col-span-4 svelte-1qu5p5x"
+              class="col-span-4 svelte-1s1441n"
             >
               <a
                 class="underlined"
@@ -500,18 +500,18 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -528,41 +528,41 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
            
         </li>
         <li
-          class="svelte-qra3ls"
+          class="svelte-w3rzzq"
           draggable="true"
         >
           <tr
-            class="svelte-1qu5p5x"
+            class="svelte-1s1441n"
             slot="item"
           >
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               5
             </td>
              
             <td
-              class="col-span-6 svelte-1qu5p5x"
+              class="col-span-6 svelte-1s1441n"
             >
               <div
-                class="undefined root svelte-1wnrcpi"
+                class="undefined root svelte-30dtyc"
               >
                 <a
                   class="flex-none"
                   href="#/album/1"
                 >
                   <img
-                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                     height="256"
                     loading="lazy"
                     width="256"
                   />
                    
                   <span
-                    class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                    class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                   >
                     <i
-                      class="material-icons svelte-dtt58s"
+                      class="material-icons svelte-1psk6yi"
                     >
                       music_note
                     </i>
@@ -571,10 +571,10 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </a>
                  
                 <div
-                  class="track svelte-1wnrcpi"
+                  class="track svelte-30dtyc"
                 >
                   <span
-                    class="title svelte-1wnrcpi"
+                    class="title svelte-30dtyc"
                   >
                     LIVE in Baghdad
                   </span>
@@ -599,7 +599,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </div>
                  
                 <div
-                  class="duration svelte-1wnrcpi"
+                  class="duration svelte-30dtyc"
                 >
                   2:59
                 </div>
@@ -608,7 +608,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="col-span-4 svelte-1qu5p5x"
+              class="col-span-4 svelte-1s1441n"
             >
               <a
                 class="underlined"
@@ -620,18 +620,18 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -648,41 +648,41 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
            
         </li>
         <li
-          class="svelte-qra3ls"
+          class="svelte-w3rzzq"
           draggable="true"
         >
           <tr
-            class="svelte-1qu5p5x"
+            class="svelte-1s1441n"
             slot="item"
           >
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               6
             </td>
              
             <td
-              class="col-span-6 svelte-1qu5p5x"
+              class="col-span-6 svelte-1s1441n"
             >
               <div
-                class="undefined root svelte-1wnrcpi"
+                class="undefined root svelte-30dtyc"
               >
                 <a
                   class="flex-none"
                   href="#/album/1"
                 >
                   <img
-                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                     height="256"
                     loading="lazy"
                     width="256"
                   />
                    
                   <span
-                    class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                    class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                   >
                     <i
-                      class="material-icons svelte-dtt58s"
+                      class="material-icons svelte-1psk6yi"
                     >
                       music_note
                     </i>
@@ -691,10 +691,10 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </a>
                  
                 <div
-                  class="track svelte-1wnrcpi"
+                  class="track svelte-30dtyc"
                 >
                   <span
-                    class="title svelte-1wnrcpi"
+                    class="title svelte-30dtyc"
                   >
                     Cats on Mars
                   </span>
@@ -719,7 +719,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </div>
                  
                 <div
-                  class="duration svelte-1wnrcpi"
+                  class="duration svelte-30dtyc"
                 >
                   0:07
                 </div>
@@ -728,7 +728,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="col-span-4 svelte-1qu5p5x"
+              class="col-span-4 svelte-1s1441n"
             >
               <a
                 class="underlined"
@@ -740,18 +740,18 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -768,41 +768,41 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
            
         </li>
         <li
-          class="svelte-qra3ls"
+          class="svelte-w3rzzq"
           draggable="true"
         >
           <tr
-            class="svelte-1qu5p5x"
+            class="svelte-1s1441n"
             slot="item"
           >
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               7
             </td>
              
             <td
-              class="col-span-6 svelte-1qu5p5x"
+              class="col-span-6 svelte-1s1441n"
             >
               <div
-                class="undefined root svelte-1wnrcpi"
+                class="undefined root svelte-30dtyc"
               >
                 <a
                   class="flex-none"
                   href="#/album/1"
                 >
                   <img
-                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                     height="256"
                     loading="lazy"
                     width="256"
                   />
                    
                   <span
-                    class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                    class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                   >
                     <i
-                      class="material-icons svelte-dtt58s"
+                      class="material-icons svelte-1psk6yi"
                     >
                       music_note
                     </i>
@@ -811,10 +811,10 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </a>
                  
                 <div
-                  class="track svelte-1wnrcpi"
+                  class="track svelte-30dtyc"
                 >
                   <span
-                    class="title svelte-1wnrcpi"
+                    class="title svelte-30dtyc"
                   >
                     Want it All Back
                   </span>
@@ -839,7 +839,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </div>
                  
                 <div
-                  class="duration svelte-1wnrcpi"
+                  class="duration svelte-30dtyc"
                 >
                   3:51
                 </div>
@@ -848,7 +848,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="col-span-4 svelte-1qu5p5x"
+              class="col-span-4 svelte-1s1441n"
             >
               <a
                 class="underlined"
@@ -860,18 +860,18 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -888,41 +888,41 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
            
         </li>
         <li
-          class="svelte-qra3ls"
+          class="svelte-w3rzzq"
           draggable="true"
         >
           <tr
-            class="svelte-1qu5p5x"
+            class="svelte-1s1441n"
             slot="item"
           >
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               8
             </td>
              
             <td
-              class="col-span-6 svelte-1qu5p5x"
+              class="col-span-6 svelte-1s1441n"
             >
               <div
-                class="undefined root svelte-1wnrcpi"
+                class="undefined root svelte-30dtyc"
               >
                 <a
                   class="flex-none"
                   href="#/album/1"
                 >
                   <img
-                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                     height="256"
                     loading="lazy"
                     width="256"
                   />
                    
                   <span
-                    class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                    class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                   >
                     <i
-                      class="material-icons svelte-dtt58s"
+                      class="material-icons svelte-1psk6yi"
                     >
                       music_note
                     </i>
@@ -931,10 +931,10 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </a>
                  
                 <div
-                  class="track svelte-1wnrcpi"
+                  class="track svelte-30dtyc"
                 >
                   <span
-                    class="title svelte-1wnrcpi"
+                    class="title svelte-30dtyc"
                   >
                     Bindy
                   </span>
@@ -959,7 +959,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </div>
                  
                 <div
-                  class="duration svelte-1wnrcpi"
+                  class="duration svelte-30dtyc"
                 >
                   0:15
                 </div>
@@ -968,7 +968,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="col-span-4 svelte-1qu5p5x"
+              class="col-span-4 svelte-1s1441n"
             >
               <a
                 class="underlined"
@@ -980,18 +980,18 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -1008,41 +1008,41 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
            
         </li>
         <li
-          class="svelte-qra3ls"
+          class="svelte-w3rzzq"
           draggable="true"
         >
           <tr
-            class="svelte-1qu5p5x"
+            class="svelte-1s1441n"
             slot="item"
           >
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               9
             </td>
              
             <td
-              class="col-span-6 svelte-1qu5p5x"
+              class="col-span-6 svelte-1s1441n"
             >
               <div
-                class="undefined root svelte-1wnrcpi"
+                class="undefined root svelte-30dtyc"
               >
                 <a
                   class="flex-none"
                   href="#/album/1"
                 >
                   <img
-                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                     height="256"
                     loading="lazy"
                     width="256"
                   />
                    
                   <span
-                    class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                    class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                   >
                     <i
-                      class="material-icons svelte-dtt58s"
+                      class="material-icons svelte-1psk6yi"
                     >
                       music_note
                     </i>
@@ -1051,10 +1051,10 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </a>
                  
                 <div
-                  class="track svelte-1wnrcpi"
+                  class="track svelte-30dtyc"
                 >
                   <span
-                    class="title svelte-1wnrcpi"
+                    class="title svelte-30dtyc"
                   >
                     You Make Me Coo
                   </span>
@@ -1079,7 +1079,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </div>
                  
                 <div
-                  class="duration svelte-1wnrcpi"
+                  class="duration svelte-30dtyc"
                 >
                   3:14
                 </div>
@@ -1088,7 +1088,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="col-span-4 svelte-1qu5p5x"
+              class="col-span-4 svelte-1s1441n"
             >
               <a
                 class="underlined"
@@ -1100,18 +1100,18 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -1128,41 +1128,41 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
            
         </li>
         <li
-          class="svelte-qra3ls"
+          class="svelte-w3rzzq"
           draggable="true"
         >
           <tr
-            class="svelte-1qu5p5x"
+            class="svelte-1s1441n"
             slot="item"
           >
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               10
             </td>
              
             <td
-              class="col-span-6 svelte-1qu5p5x"
+              class="col-span-6 svelte-1s1441n"
             >
               <div
-                class="undefined root svelte-1wnrcpi"
+                class="undefined root svelte-30dtyc"
               >
                 <a
                   class="flex-none"
                   href="#/album/1"
                 >
                   <img
-                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                     height="256"
                     loading="lazy"
                     width="256"
                   />
                    
                   <span
-                    class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                    class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                   >
                     <i
-                      class="material-icons svelte-dtt58s"
+                      class="material-icons svelte-1psk6yi"
                     >
                       music_note
                     </i>
@@ -1171,10 +1171,10 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </a>
                  
                 <div
-                  class="track svelte-1wnrcpi"
+                  class="track svelte-30dtyc"
                 >
                   <span
-                    class="title svelte-1wnrcpi"
+                    class="title svelte-30dtyc"
                   >
                     Vitamin B
                   </span>
@@ -1199,7 +1199,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </div>
                  
                 <div
-                  class="duration svelte-1wnrcpi"
+                  class="duration svelte-30dtyc"
                 >
                   4:06
                 </div>
@@ -1208,7 +1208,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="col-span-4 svelte-1qu5p5x"
+              class="col-span-4 svelte-1s1441n"
             >
               <a
                 class="underlined"
@@ -1220,18 +1220,18 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -1248,41 +1248,41 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
            
         </li>
         <li
-          class="svelte-qra3ls"
+          class="svelte-w3rzzq"
           draggable="true"
         >
           <tr
-            class="svelte-1qu5p5x"
+            class="svelte-1s1441n"
             slot="item"
           >
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               11
             </td>
              
             <td
-              class="col-span-6 svelte-1qu5p5x"
+              class="col-span-6 svelte-1s1441n"
             >
               <div
-                class="undefined root svelte-1wnrcpi"
+                class="undefined root svelte-30dtyc"
               >
                 <a
                   class="flex-none"
                   href="#/album/1"
                 >
                   <img
-                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                     height="256"
                     loading="lazy"
                     width="256"
                   />
                    
                   <span
-                    class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                    class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                   >
                     <i
-                      class="material-icons svelte-dtt58s"
+                      class="material-icons svelte-1psk6yi"
                     >
                       music_note
                     </i>
@@ -1291,10 +1291,10 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </a>
                  
                 <div
-                  class="track svelte-1wnrcpi"
+                  class="track svelte-30dtyc"
                 >
                   <span
-                    class="title svelte-1wnrcpi"
+                    class="title svelte-30dtyc"
                   >
                     Green Bird
                   </span>
@@ -1319,7 +1319,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </div>
                  
                 <div
-                  class="duration svelte-1wnrcpi"
+                  class="duration svelte-30dtyc"
                 >
                   2:33
                 </div>
@@ -1328,7 +1328,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="col-span-4 svelte-1qu5p5x"
+              class="col-span-4 svelte-1s1441n"
             >
               <a
                 class="underlined"
@@ -1340,18 +1340,18 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -1368,41 +1368,41 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
            
         </li>
         <li
-          class="svelte-qra3ls"
+          class="svelte-w3rzzq"
           draggable="true"
         >
           <tr
-            class="svelte-1qu5p5x"
+            class="svelte-1s1441n"
             slot="item"
           >
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               12
             </td>
              
             <td
-              class="col-span-6 svelte-1qu5p5x"
+              class="col-span-6 svelte-1s1441n"
             >
               <div
-                class="undefined root svelte-1wnrcpi"
+                class="undefined root svelte-30dtyc"
               >
                 <a
                   class="flex-none"
                   href="#/album/1"
                 >
                   <img
-                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                     height="256"
                     loading="lazy"
                     width="256"
                   />
                    
                   <span
-                    class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                    class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                   >
                     <i
-                      class="material-icons svelte-dtt58s"
+                      class="material-icons svelte-1psk6yi"
                     >
                       music_note
                     </i>
@@ -1411,10 +1411,10 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </a>
                  
                 <div
-                  class="track svelte-1wnrcpi"
+                  class="track svelte-30dtyc"
                 >
                   <span
-                    class="title svelte-1wnrcpi"
+                    class="title svelte-30dtyc"
                   >
                     ELM
                   </span>
@@ -1439,7 +1439,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </div>
                  
                 <div
-                  class="duration svelte-1wnrcpi"
+                  class="duration svelte-30dtyc"
                 >
                   6:55
                 </div>
@@ -1448,7 +1448,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="col-span-4 svelte-1qu5p5x"
+              class="col-span-4 svelte-1s1441n"
             >
               <a
                 class="underlined"
@@ -1460,18 +1460,18 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -1488,41 +1488,41 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
            
         </li>
         <li
-          class="svelte-qra3ls"
+          class="svelte-w3rzzq"
           draggable="true"
         >
           <tr
-            class="svelte-1qu5p5x"
+            class="svelte-1s1441n"
             slot="item"
           >
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               13
             </td>
              
             <td
-              class="col-span-6 svelte-1qu5p5x"
+              class="col-span-6 svelte-1s1441n"
             >
               <div
-                class="undefined root svelte-1wnrcpi"
+                class="undefined root svelte-30dtyc"
               >
                 <a
                   class="flex-none"
                   href="#/album/1"
                 >
                   <img
-                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                     height="256"
                     loading="lazy"
                     width="256"
                   />
                    
                   <span
-                    class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                    class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                   >
                     <i
-                      class="material-icons svelte-dtt58s"
+                      class="material-icons svelte-1psk6yi"
                     >
                       music_note
                     </i>
@@ -1531,10 +1531,10 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </a>
                  
                 <div
-                  class="track svelte-1wnrcpi"
+                  class="track svelte-30dtyc"
                 >
                   <span
-                    class="title svelte-1wnrcpi"
+                    class="title svelte-30dtyc"
                   >
                     Vitamin C
                   </span>
@@ -1559,7 +1559,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </div>
                  
                 <div
-                  class="duration svelte-1wnrcpi"
+                  class="duration svelte-30dtyc"
                 >
                   5:24
                 </div>
@@ -1568,7 +1568,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="col-span-4 svelte-1qu5p5x"
+              class="col-span-4 svelte-1s1441n"
             >
               <a
                 class="underlined"
@@ -1580,18 +1580,18 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -1608,41 +1608,41 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
            
         </li>
         <li
-          class="svelte-qra3ls"
+          class="svelte-w3rzzq"
           draggable="true"
         >
           <tr
-            class="svelte-1qu5p5x"
+            class="svelte-1s1441n"
             slot="item"
           >
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               14
             </td>
              
             <td
-              class="col-span-6 svelte-1qu5p5x"
+              class="col-span-6 svelte-1s1441n"
             >
               <div
-                class="undefined root svelte-1wnrcpi"
+                class="undefined root svelte-30dtyc"
               >
                 <a
                   class="flex-none"
                   href="#/album/1"
                 >
                   <img
-                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                     height="256"
                     loading="lazy"
                     width="256"
                   />
                    
                   <span
-                    class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                    class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                   >
                     <i
-                      class="material-icons svelte-dtt58s"
+                      class="material-icons svelte-1psk6yi"
                     >
                       music_note
                     </i>
@@ -1651,10 +1651,10 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </a>
                  
                 <div
-                  class="track svelte-1wnrcpi"
+                  class="track svelte-30dtyc"
                 >
                   <span
-                    class="title svelte-1wnrcpi"
+                    class="title svelte-30dtyc"
                   >
                     Gateway
                   </span>
@@ -1679,7 +1679,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </div>
                  
                 <div
-                  class="duration svelte-1wnrcpi"
+                  class="duration svelte-30dtyc"
                 >
                   0:16
                 </div>
@@ -1688,7 +1688,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="col-span-4 svelte-1qu5p5x"
+              class="col-span-4 svelte-1s1441n"
             >
               <a
                 class="underlined"
@@ -1700,18 +1700,18 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -1728,41 +1728,41 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
            
         </li>
         <li
-          class="svelte-qra3ls"
+          class="svelte-w3rzzq"
           draggable="true"
         >
           <tr
-            class="svelte-1qu5p5x"
+            class="svelte-1s1441n"
             slot="item"
           >
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               15
             </td>
              
             <td
-              class="col-span-6 svelte-1qu5p5x"
+              class="col-span-6 svelte-1s1441n"
             >
               <div
-                class="undefined root svelte-1wnrcpi"
+                class="undefined root svelte-30dtyc"
               >
                 <a
                   class="flex-none"
                   href="#/album/1"
                 >
                   <img
-                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                     height="256"
                     loading="lazy"
                     width="256"
                   />
                    
                   <span
-                    class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                    class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                   >
                     <i
-                      class="material-icons svelte-dtt58s"
+                      class="material-icons svelte-1psk6yi"
                     >
                       music_note
                     </i>
@@ -1771,10 +1771,10 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </a>
                  
                 <div
-                  class="track svelte-1wnrcpi"
+                  class="track svelte-30dtyc"
                 >
                   <span
-                    class="title svelte-1wnrcpi"
+                    class="title svelte-30dtyc"
                   >
                     The Singing Sea
                   </span>
@@ -1799,7 +1799,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </div>
                  
                 <div
-                  class="duration svelte-1wnrcpi"
+                  class="duration svelte-30dtyc"
                 >
                   6:41
                 </div>
@@ -1808,7 +1808,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="col-span-4 svelte-1qu5p5x"
+              class="col-span-4 svelte-1s1441n"
             >
               <a
                 class="underlined"
@@ -1820,18 +1820,18 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -1848,41 +1848,41 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
            
         </li>
         <li
-          class="svelte-qra3ls"
+          class="svelte-w3rzzq"
           draggable="true"
         >
           <tr
-            class="svelte-1qu5p5x"
+            class="svelte-1s1441n"
             slot="item"
           >
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               16
             </td>
              
             <td
-              class="col-span-6 svelte-1qu5p5x"
+              class="col-span-6 svelte-1s1441n"
             >
               <div
-                class="undefined root svelte-1wnrcpi"
+                class="undefined root svelte-30dtyc"
               >
                 <a
                   class="flex-none"
                   href="#/album/1"
                 >
                   <img
-                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                     height="256"
                     loading="lazy"
                     width="256"
                   />
                    
                   <span
-                    class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                    class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                   >
                     <i
-                      class="material-icons svelte-dtt58s"
+                      class="material-icons svelte-1psk6yi"
                     >
                       music_note
                     </i>
@@ -1891,10 +1891,10 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </a>
                  
                 <div
-                  class="track svelte-1wnrcpi"
+                  class="track svelte-30dtyc"
                 >
                   <span
-                    class="title svelte-1wnrcpi"
+                    class="title svelte-30dtyc"
                   >
                     The Egg and You!
                   </span>
@@ -1919,7 +1919,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </div>
                  
                 <div
-                  class="duration svelte-1wnrcpi"
+                  class="duration svelte-30dtyc"
                 >
                   4:47
                 </div>
@@ -1928,7 +1928,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="col-span-4 svelte-1qu5p5x"
+              class="col-span-4 svelte-1s1441n"
             >
               <a
                 class="underlined"
@@ -1940,18 +1940,18 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -1968,41 +1968,41 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
            
         </li>
         <li
-          class="svelte-qra3ls"
+          class="svelte-w3rzzq"
           draggable="true"
         >
           <tr
-            class="svelte-1qu5p5x"
+            class="svelte-1s1441n"
             slot="item"
           >
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               17
             </td>
              
             <td
-              class="col-span-6 svelte-1qu5p5x"
+              class="col-span-6 svelte-1s1441n"
             >
               <div
-                class="undefined root svelte-1wnrcpi"
+                class="undefined root svelte-30dtyc"
               >
                 <a
                   class="flex-none"
                   href="#/album/1"
                 >
                   <img
-                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                     height="256"
                     loading="lazy"
                     width="256"
                   />
                    
                   <span
-                    class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                    class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                   >
                     <i
-                      class="material-icons svelte-dtt58s"
+                      class="material-icons svelte-1psk6yi"
                     >
                       music_note
                     </i>
@@ -2011,10 +2011,10 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </a>
                  
                 <div
-                  class="track svelte-1wnrcpi"
+                  class="track svelte-30dtyc"
                 >
                   <span
-                    class="title svelte-1wnrcpi"
+                    class="title svelte-30dtyc"
                   >
                     Forever Broke
                   </span>
@@ -2039,7 +2039,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </div>
                  
                 <div
-                  class="duration svelte-1wnrcpi"
+                  class="duration svelte-30dtyc"
                 >
                   1:36
                 </div>
@@ -2048,7 +2048,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="col-span-4 svelte-1qu5p5x"
+              class="col-span-4 svelte-1s1441n"
             >
               <a
                 class="underlined"
@@ -2060,18 +2060,18 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -2088,41 +2088,41 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
            
         </li>
         <li
-          class="svelte-qra3ls"
+          class="svelte-w3rzzq"
           draggable="true"
         >
           <tr
-            class="svelte-1qu5p5x"
+            class="svelte-1s1441n"
             slot="item"
           >
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               18
             </td>
              
             <td
-              class="col-span-6 svelte-1qu5p5x"
+              class="col-span-6 svelte-1s1441n"
             >
               <div
-                class="undefined root svelte-1wnrcpi"
+                class="undefined root svelte-30dtyc"
               >
                 <a
                   class="flex-none"
                   href="#/album/1"
                 >
                   <img
-                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                    class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                     height="256"
                     loading="lazy"
                     width="256"
                   />
                    
                   <span
-                    class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                    class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                   >
                     <i
-                      class="material-icons svelte-dtt58s"
+                      class="material-icons svelte-1psk6yi"
                     >
                       music_note
                     </i>
@@ -2131,10 +2131,10 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </a>
                  
                 <div
-                  class="track svelte-1wnrcpi"
+                  class="track svelte-30dtyc"
                 >
                   <span
-                    class="title svelte-1wnrcpi"
+                    class="title svelte-30dtyc"
                   >
                     Power of Kungfu Remix
                   </span>
@@ -2159,7 +2159,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
                 </div>
                  
                 <div
-                  class="duration svelte-1wnrcpi"
+                  class="duration svelte-30dtyc"
                 >
                   2:22
                 </div>
@@ -2168,7 +2168,7 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="col-span-4 svelte-1qu5p5x"
+              class="col-span-4 svelte-1s1441n"
             >
               <a
                 class="underlined"
@@ -2180,18 +2180,18 @@ exports[`Toolshot components/PlaylistTracksTable/PlaylistTracksTable.tools.svelt
             </td>
              
             <td
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>

--- a/common/ui/src/components/Progress/__snapshots__/Progress.tools.shot
+++ b/common/ui/src/components/Progress/__snapshots__/Progress.tools.shot
@@ -3,15 +3,15 @@
 exports[`Toolshot components/Progress/Progress.tools.svelte: Components/Progress 1`] = `
 <span>
   <div
-    class="wrapper svelte-kz5qng"
+    class="wrapper svelte-11b7si"
     role="progressbar"
   >
     <div
-      class="inc svelte-kz5qng"
+      class="inc svelte-11b7si"
     />
      
     <div
-      class="dec svelte-kz5qng"
+      class="dec svelte-11b7si"
     />
   </div>
 </span>

--- a/common/ui/src/components/Sheet/__snapshots__/Sheet.tools.shot
+++ b/common/ui/src/components/Sheet/__snapshots__/Sheet.tools.shot
@@ -2,20 +2,20 @@
 
 exports[`Toolshot components/Sheet/Sheet.tools.svelte: Components/Sheet 1`] = `
 <div
-  class="wrapper svelte-81oo1z"
+  class="wrapper svelte-1ruiooq"
 >
   <div
-    class="svelte-1ieq8lj"
+    class="svelte-ccx7ge"
   >
     <div
-      class="main svelte-1ieq8lj"
+      class="main svelte-ccx7ge"
     >
       <section
-        class="svelte-81oo1z"
+        class="svelte-1ruiooq"
         slot="main"
       >
         <button
-          class="svelte-1vd9h50"
+          class="svelte-1e4q28k"
         >
            
           <span>

--- a/common/ui/src/components/Slider/__snapshots__/Slider.tools.shot
+++ b/common/ui/src/components/Slider/__snapshots__/Slider.tools.shot
@@ -3,20 +3,20 @@
 exports[`Toolshot components/Slider/Slider.tools.svelte: Components/Slider 1`] = `
 <span>
   <div
-    class="wrapper w-1/2 svelte-1gmj9k4"
+    class="wrapper w-1/2 svelte-flvs0m"
   >
     <input
-      class="w-1/2 svelte-1gmj9k4"
+      class="w-1/2 svelte-flvs0m"
       max="100"
       min="0"
       type="range"
     />
      
     <div
-      class="sliderTrack svelte-1gmj9k4"
+      class="sliderTrack svelte-flvs0m"
     >
       <span
-        class="progress svelte-1gmj9k4"
+        class="progress svelte-flvs0m"
         style="right:90%"
       />
     </div>

--- a/common/ui/src/components/SortableList/__snapshots__/SortableList.tools.shot
+++ b/common/ui/src/components/SortableList/__snapshots__/SortableList.tools.shot
@@ -4,15 +4,15 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
 <div>
   <ol>
     <li
-      class="svelte-qra3ls"
+      class="svelte-w3rzzq"
       draggable="true"
     >
       <div
-        class="svelte-1falwho"
+        class="svelte-1334q7p"
         slot="item"
       >
         <div
-          class="col-span-11 root svelte-1wnrcpi"
+          class="col-span-11 root svelte-30dtyc"
         >
           <a
             class="flex-none"
@@ -20,7 +20,7 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
           >
             <img
               alt="./# Films/cover.jpg"
-              class="h-16 w-16 text-xs actionable rounded-sm svelte-dtt58s"
+              class="h-16 w-16 text-xs actionable rounded-sm svelte-1psk6yi"
               height="256"
               loading="lazy"
               src="./%23 Films/cover.jpg"
@@ -31,10 +31,10 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
           </a>
            
           <div
-            class="track svelte-1wnrcpi"
+            class="track svelte-30dtyc"
           >
             <span
-              class="title svelte-1wnrcpi"
+              class="title svelte-30dtyc"
             >
               file 1
             </span>
@@ -51,7 +51,7 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
           </div>
            
           <div
-            class="duration svelte-1wnrcpi"
+            class="duration svelte-30dtyc"
           >
             3:38
           </div>
@@ -60,10 +60,10 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
          
         <span>
           <button
-            class="iconOnly noBorder svelte-1vd9h50"
+            class="iconOnly noBorder svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               close
             </i>
@@ -76,15 +76,15 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
        
     </li>
     <li
-      class="svelte-qra3ls"
+      class="svelte-w3rzzq"
       draggable="true"
     >
       <div
-        class="svelte-1falwho"
+        class="svelte-1334q7p"
         slot="item"
       >
         <div
-          class="col-span-11 root svelte-1wnrcpi"
+          class="col-span-11 root svelte-30dtyc"
         >
           <a
             class="flex-none"
@@ -92,7 +92,7 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
           >
             <img
               alt="./# Films/cover.jpg"
-              class="h-16 w-16 text-xs actionable rounded-sm svelte-dtt58s"
+              class="h-16 w-16 text-xs actionable rounded-sm svelte-1psk6yi"
               height="256"
               loading="lazy"
               src="./%23 Films/cover.jpg"
@@ -103,10 +103,10 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
           </a>
            
           <div
-            class="track svelte-1wnrcpi"
+            class="track svelte-30dtyc"
           >
             <span
-              class="title svelte-1wnrcpi"
+              class="title svelte-30dtyc"
             >
               file 2
             </span>
@@ -123,7 +123,7 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
           </div>
            
           <div
-            class="duration svelte-1wnrcpi"
+            class="duration svelte-30dtyc"
           >
             0:04
           </div>
@@ -132,10 +132,10 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
          
         <span>
           <button
-            class="iconOnly noBorder svelte-1vd9h50"
+            class="iconOnly noBorder svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               close
             </i>
@@ -148,15 +148,15 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
        
     </li>
     <li
-      class="svelte-qra3ls"
+      class="svelte-w3rzzq"
       draggable="true"
     >
       <div
-        class="svelte-1falwho"
+        class="svelte-1334q7p"
         slot="item"
       >
         <div
-          class="col-span-11 root svelte-1wnrcpi"
+          class="col-span-11 root svelte-30dtyc"
         >
           <a
             class="flex-none"
@@ -164,7 +164,7 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
           >
             <img
               alt="./cover.jpg"
-              class="h-16 w-16 text-xs actionable rounded-sm svelte-dtt58s"
+              class="h-16 w-16 text-xs actionable rounded-sm svelte-1psk6yi"
               height="256"
               loading="lazy"
               src="./cover.jpg"
@@ -175,10 +175,10 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
           </a>
            
           <div
-            class="track svelte-1wnrcpi"
+            class="track svelte-30dtyc"
           >
             <span
-              class="title svelte-1wnrcpi"
+              class="title svelte-30dtyc"
             >
               file 3
             </span>
@@ -195,7 +195,7 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
           </div>
            
           <div
-            class="duration svelte-1wnrcpi"
+            class="duration svelte-30dtyc"
           >
             0:02
           </div>
@@ -204,10 +204,10 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
          
         <span>
           <button
-            class="iconOnly noBorder svelte-1vd9h50"
+            class="iconOnly noBorder svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               close
             </i>
@@ -220,15 +220,15 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
        
     </li>
     <li
-      class="svelte-qra3ls"
+      class="svelte-w3rzzq"
       draggable="true"
     >
       <div
-        class="svelte-1falwho"
+        class="svelte-1334q7p"
         slot="item"
       >
         <div
-          class="col-span-11 root svelte-1wnrcpi"
+          class="col-span-11 root svelte-30dtyc"
         >
           <a
             class="flex-none"
@@ -236,7 +236,7 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
           >
             <img
               alt="./cover.jpg"
-              class="h-16 w-16 text-xs actionable rounded-sm svelte-dtt58s"
+              class="h-16 w-16 text-xs actionable rounded-sm svelte-1psk6yi"
               height="256"
               loading="lazy"
               src="./cover.jpg"
@@ -247,10 +247,10 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
           </a>
            
           <div
-            class="track svelte-1wnrcpi"
+            class="track svelte-30dtyc"
           >
             <span
-              class="title svelte-1wnrcpi"
+              class="title svelte-30dtyc"
             >
               file 4
             </span>
@@ -267,7 +267,7 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
           </div>
            
           <div
-            class="duration svelte-1wnrcpi"
+            class="duration svelte-30dtyc"
           >
             0:03
           </div>
@@ -276,10 +276,10 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
          
         <span>
           <button
-            class="iconOnly noBorder svelte-1vd9h50"
+            class="iconOnly noBorder svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               close
             </i>
@@ -292,15 +292,15 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
        
     </li>
     <li
-      class="svelte-qra3ls"
+      class="svelte-w3rzzq"
       draggable="true"
     >
       <div
-        class="svelte-1falwho"
+        class="svelte-1334q7p"
         slot="item"
       >
         <div
-          class="col-span-11 root svelte-1wnrcpi"
+          class="col-span-11 root svelte-30dtyc"
         >
           <a
             class="flex-none"
@@ -308,7 +308,7 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
           >
             <img
               alt="./# Films/cover.jpg"
-              class="h-16 w-16 text-xs actionable rounded-sm svelte-dtt58s"
+              class="h-16 w-16 text-xs actionable rounded-sm svelte-1psk6yi"
               height="256"
               loading="lazy"
               src="./%23 Films/cover.jpg"
@@ -319,10 +319,10 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
           </a>
            
           <div
-            class="track svelte-1wnrcpi"
+            class="track svelte-30dtyc"
           >
             <span
-              class="title svelte-1wnrcpi"
+              class="title svelte-30dtyc"
             >
               file 1
             </span>
@@ -339,7 +339,7 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
           </div>
            
           <div
-            class="duration svelte-1wnrcpi"
+            class="duration svelte-30dtyc"
           >
             3:38
           </div>
@@ -348,10 +348,10 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
          
         <span>
           <button
-            class="iconOnly noBorder svelte-1vd9h50"
+            class="iconOnly noBorder svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               close
             </i>
@@ -364,15 +364,15 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
        
     </li>
     <li
-      class="svelte-qra3ls"
+      class="svelte-w3rzzq"
       draggable="true"
     >
       <div
-        class="svelte-1falwho"
+        class="svelte-1334q7p"
         slot="item"
       >
         <div
-          class="col-span-11 root svelte-1wnrcpi"
+          class="col-span-11 root svelte-30dtyc"
         >
           <a
             class="flex-none"
@@ -380,7 +380,7 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
           >
             <img
               alt="./# Films/cover.jpg"
-              class="h-16 w-16 text-xs actionable rounded-sm svelte-dtt58s"
+              class="h-16 w-16 text-xs actionable rounded-sm svelte-1psk6yi"
               height="256"
               loading="lazy"
               src="./%23 Films/cover.jpg"
@@ -391,10 +391,10 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
           </a>
            
           <div
-            class="track svelte-1wnrcpi"
+            class="track svelte-30dtyc"
           >
             <span
-              class="title svelte-1wnrcpi"
+              class="title svelte-30dtyc"
             >
               file 2
             </span>
@@ -411,7 +411,7 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
           </div>
            
           <div
-            class="duration svelte-1wnrcpi"
+            class="duration svelte-30dtyc"
           >
             0:04
           </div>
@@ -420,10 +420,10 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
          
         <span>
           <button
-            class="iconOnly noBorder svelte-1vd9h50"
+            class="iconOnly noBorder svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               close
             </i>
@@ -436,15 +436,15 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
        
     </li>
     <li
-      class="svelte-qra3ls"
+      class="svelte-w3rzzq"
       draggable="true"
     >
       <div
-        class="svelte-1falwho"
+        class="svelte-1334q7p"
         slot="item"
       >
         <div
-          class="col-span-11 root svelte-1wnrcpi"
+          class="col-span-11 root svelte-30dtyc"
         >
           <a
             class="flex-none"
@@ -452,7 +452,7 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
           >
             <img
               alt="./cover.jpg"
-              class="h-16 w-16 text-xs actionable rounded-sm svelte-dtt58s"
+              class="h-16 w-16 text-xs actionable rounded-sm svelte-1psk6yi"
               height="256"
               loading="lazy"
               src="./cover.jpg"
@@ -463,10 +463,10 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
           </a>
            
           <div
-            class="track svelte-1wnrcpi"
+            class="track svelte-30dtyc"
           >
             <span
-              class="title svelte-1wnrcpi"
+              class="title svelte-30dtyc"
             >
               file 3
             </span>
@@ -483,7 +483,7 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
           </div>
            
           <div
-            class="duration svelte-1wnrcpi"
+            class="duration svelte-30dtyc"
           >
             0:02
           </div>
@@ -492,10 +492,10 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
          
         <span>
           <button
-            class="iconOnly noBorder svelte-1vd9h50"
+            class="iconOnly noBorder svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               close
             </i>
@@ -508,15 +508,15 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
        
     </li>
     <li
-      class="svelte-qra3ls"
+      class="svelte-w3rzzq"
       draggable="true"
     >
       <div
-        class="svelte-1falwho"
+        class="svelte-1334q7p"
         slot="item"
       >
         <div
-          class="col-span-11 root svelte-1wnrcpi"
+          class="col-span-11 root svelte-30dtyc"
         >
           <a
             class="flex-none"
@@ -524,7 +524,7 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
           >
             <img
               alt="./cover.jpg"
-              class="h-16 w-16 text-xs actionable rounded-sm svelte-dtt58s"
+              class="h-16 w-16 text-xs actionable rounded-sm svelte-1psk6yi"
               height="256"
               loading="lazy"
               src="./cover.jpg"
@@ -535,10 +535,10 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
           </a>
            
           <div
-            class="track svelte-1wnrcpi"
+            class="track svelte-30dtyc"
           >
             <span
-              class="title svelte-1wnrcpi"
+              class="title svelte-30dtyc"
             >
               file 4
             </span>
@@ -555,7 +555,7 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
           </div>
            
           <div
-            class="duration svelte-1wnrcpi"
+            class="duration svelte-30dtyc"
           >
             0:03
           </div>
@@ -564,10 +564,10 @@ exports[`Toolshot components/SortableList/SortableList.tools.svelte: Components/
          
         <span>
           <button
-            class="iconOnly noBorder svelte-1vd9h50"
+            class="iconOnly noBorder svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               close
             </i>

--- a/common/ui/src/components/Sticky/__snapshots__/Sticky.tools.shot
+++ b/common/ui/src/components/Sticky/__snapshots__/Sticky.tools.shot
@@ -2,6 +2,6 @@
 
 exports[`Toolshot components/Sticky/Sticky.tools.svelte: Components/Sticky 1`] = `
 <span
-  class="sentinel svelte-1iy4s0s"
+  class="sentinel svelte-1oaxvmy"
 />
 `;

--- a/common/ui/src/components/SubHeading/__snapshots__/SubHeading.tools.shot
+++ b/common/ui/src/components/SubHeading/__snapshots__/SubHeading.tools.shot
@@ -2,7 +2,7 @@
 
 exports[`Toolshot components/SubHeading/SubHeading.tools.svelte: Components/Sub Heading 1`] = `
 <h4
-  class=" svelte-yxo9fq"
+  class=" svelte-177xz1h"
 >
   This is a sub title
 </h4>

--- a/common/ui/src/components/TextInput/__snapshots__/TextInput.tools.shot
+++ b/common/ui/src/components/TextInput/__snapshots__/TextInput.tools.shot
@@ -5,11 +5,11 @@ exports[`Toolshot components/TextInput/TextInput.tools.svelte: Default 1`] = `
   class="inline-block w-64"
 >
   <span
-    class="svelte-1crflxh"
+    class="svelte-1rbj4tt"
   >
      
     <input
-      class="svelte-1crflxh"
+      class="svelte-1rbj4tt"
       placeholder=""
       type="text"
     />
@@ -22,16 +22,16 @@ exports[`Toolshot components/TextInput/TextInput.tools.svelte: With icon and pla
   class="inline-block w-64"
 >
   <span
-    class="svelte-1crflxh icon"
+    class="svelte-1rbj4tt icon"
   >
     <i
-      class="material-icons svelte-1crflxh"
+      class="material-icons svelte-1rbj4tt"
     >
       search
     </i>
      
     <input
-      class="svelte-1crflxh"
+      class="svelte-1rbj4tt"
       placeholder="search..."
       type="search"
     />
@@ -44,16 +44,16 @@ exports[`Toolshot components/TextInput/TextInput.tools.svelte: With value 1`] = 
   class="inline-block w-64"
 >
   <span
-    class="svelte-1crflxh icon"
+    class="svelte-1rbj4tt icon"
   >
     <i
-      class="material-icons svelte-1crflxh"
+      class="material-icons svelte-1rbj4tt"
     >
       person
     </i>
      
     <input
-      class="svelte-1crflxh"
+      class="svelte-1rbj4tt"
       placeholder=""
       type="text"
     />

--- a/common/ui/src/components/Track/__snapshots__/Track.tools.shot
+++ b/common/ui/src/components/Track/__snapshots__/Track.tools.shot
@@ -3,7 +3,7 @@
 exports[`Toolshot components/Track/Track.tools.svelte: Default 1`] = `
 <div>
   <div
-    class="undefined root svelte-1wnrcpi"
+    class="undefined root svelte-30dtyc"
   >
     <a
       class="flex-none"
@@ -11,7 +11,7 @@ exports[`Toolshot components/Track/Track.tools.svelte: Default 1`] = `
     >
       <img
         alt="./cover.jpg"
-        class="h-16 w-16 text-xs actionable rounded-sm svelte-dtt58s"
+        class="h-16 w-16 text-xs actionable rounded-sm svelte-1psk6yi"
         height="256"
         loading="lazy"
         src="./cover.jpg"
@@ -22,10 +22,10 @@ exports[`Toolshot components/Track/Track.tools.svelte: Default 1`] = `
     </a>
      
     <div
-      class="track svelte-1wnrcpi"
+      class="track svelte-30dtyc"
     >
       <span
-        class="title svelte-1wnrcpi"
+        class="title svelte-30dtyc"
       >
         Mama got a girlfriend
       </span>
@@ -49,7 +49,7 @@ exports[`Toolshot components/Track/Track.tools.svelte: Default 1`] = `
 exports[`Toolshot components/Track/Track.tools.svelte: With details 1`] = `
 <div>
   <div
-    class="undefined root svelte-1wnrcpi"
+    class="undefined root svelte-30dtyc"
   >
     <a
       class="flex-none"
@@ -57,7 +57,7 @@ exports[`Toolshot components/Track/Track.tools.svelte: With details 1`] = `
     >
       <img
         alt="./cover.jpg"
-        class="h-16 w-16 text-xs actionable rounded-sm svelte-dtt58s"
+        class="h-16 w-16 text-xs actionable rounded-sm svelte-1psk6yi"
         height="256"
         loading="lazy"
         src="./cover.jpg"
@@ -68,10 +68,10 @@ exports[`Toolshot components/Track/Track.tools.svelte: With details 1`] = `
     </a>
      
     <div
-      class="track svelte-1wnrcpi"
+      class="track svelte-30dtyc"
     >
       <span
-        class="title svelte-1wnrcpi"
+        class="title svelte-30dtyc"
       >
         Mama got a girlfriend
       </span>
@@ -88,7 +88,7 @@ exports[`Toolshot components/Track/Track.tools.svelte: With details 1`] = `
     </div>
      
     <div
-      class="duration svelte-1wnrcpi"
+      class="duration svelte-30dtyc"
     >
       2:06
     </div>
@@ -100,7 +100,7 @@ exports[`Toolshot components/Track/Track.tools.svelte: With details 1`] = `
 exports[`Toolshot components/Track/Track.tools.svelte: With menu 1`] = `
 <div>
   <div
-    class="undefined root svelte-1wnrcpi"
+    class="undefined root svelte-30dtyc"
   >
     <a
       class="flex-none"
@@ -108,7 +108,7 @@ exports[`Toolshot components/Track/Track.tools.svelte: With menu 1`] = `
     >
       <img
         alt="./cover.jpg"
-        class="h-16 w-16 text-xs actionable rounded-sm svelte-dtt58s"
+        class="h-16 w-16 text-xs actionable rounded-sm svelte-1psk6yi"
         height="256"
         loading="lazy"
         src="./cover.jpg"
@@ -119,10 +119,10 @@ exports[`Toolshot components/Track/Track.tools.svelte: With menu 1`] = `
     </a>
      
     <div
-      class="track svelte-1wnrcpi"
+      class="track svelte-30dtyc"
     >
       <span
-        class="title svelte-1wnrcpi"
+        class="title svelte-30dtyc"
       >
         Mama got a girlfriend
       </span>
@@ -142,13 +142,13 @@ exports[`Toolshot components/Track/Track.tools.svelte: With menu 1`] = `
     <span
       aria-expanded="false"
       aria-haspopup="menu"
-      class="wrapper svelte-1x6dshm"
+      class="wrapper svelte-11prmkk"
     >
       <button
-        class="iconOnly noBorder svelte-1vd9h50"
+        class="iconOnly noBorder svelte-1e4q28k"
       >
         <i
-          class="material-icons svelte-1vd9h50"
+          class="material-icons svelte-1e4q28k"
         >
           more_vert
         </i>

--- a/common/ui/src/components/TracksQueue/__snapshots__/TracksQueue.tools.shot
+++ b/common/ui/src/components/TracksQueue/__snapshots__/TracksQueue.tools.shot
@@ -3,39 +3,39 @@
 exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: Empty 1`] = `
 <div>
   <span
-    class="sentinel svelte-1iy4s0s"
+    class="sentinel svelte-1oaxvmy"
   />
    
   <nav
-    class="svelte-1iy4s0s"
+    class="svelte-1oaxvmy"
   >
     <header
-      class="svelte-eibfn2"
+      class="svelte-1lxfxfd"
     >
       <h3>
         0 tracks
       </h3>
        
       <span
-        class="totalDuration svelte-eibfn2"
+        class="totalDuration svelte-1lxfxfd"
       />
        
     </header>
   </nav>
    
   <header
-    class=" svelte-8800qh"
+    class=" svelte-t58ezf"
     style="--image: url(../images/jason-rosewell-ASKeuOZqhYU-unsplash.jpg); --shade-color: rgba(0, 0, 0, 0.7); --bgPosition: center;"
   >
     <h1
-      class="svelte-8800qh"
+      class="svelte-t58ezf"
     >
       Queue
     </h1>
   </header>
    
   <div
-    class="svelte-eibfn2"
+    class="svelte-1lxfxfd"
   >
     <ol />
   </div>
@@ -45,14 +45,14 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: Empty 1`] = `
 exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track list 1`] = `
 <div>
   <span
-    class="sentinel svelte-1iy4s0s"
+    class="sentinel svelte-1oaxvmy"
   />
    
   <nav
-    class="svelte-1iy4s0s"
+    class="svelte-1oaxvmy"
   >
     <header
-      class="svelte-eibfn2"
+      class="svelte-1lxfxfd"
     >
       <h3>
         8 tracks
@@ -61,13 +61,13 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
       <span
         aria-expanded="false"
         aria-haspopup="menu"
-        class="wrapper svelte-1x6dshm"
+        class="wrapper svelte-11prmkk"
       >
         <button
-          class="iconOnly noBorder svelte-1vd9h50"
+          class="iconOnly noBorder svelte-1e4q28k"
         >
           <i
-            class="material-icons svelte-1vd9h50"
+            class="material-icons svelte-1e4q28k"
           >
             library_add
           </i>
@@ -81,16 +81,16 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
       
        
       <span
-        class="totalDuration svelte-eibfn2"
+        class="totalDuration svelte-1lxfxfd"
       >
         7:34
       </span>
        
       <button
-        class="iconOnly svelte-1vd9h50"
+        class="iconOnly svelte-1e4q28k"
       >
         <i
-          class="material-icons svelte-1vd9h50"
+          class="material-icons svelte-1e4q28k"
         >
           delete
         </i>
@@ -103,30 +103,30 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
   </nav>
    
   <header
-    class=" svelte-8800qh"
+    class=" svelte-t58ezf"
     style="--image: url(../images/jason-rosewell-ASKeuOZqhYU-unsplash.jpg); --shade-color: rgba(0, 0, 0, 0.7); --bgPosition: center;"
   >
     <h1
-      class="svelte-8800qh"
+      class="svelte-t58ezf"
     >
       Queue
     </h1>
   </header>
    
   <div
-    class="svelte-eibfn2"
+    class="svelte-1lxfxfd"
   >
     <ol>
       <li
-        class="svelte-qra3ls"
+        class="svelte-w3rzzq"
         draggable="true"
       >
         <span
-          class="row svelte-eibfn2 current"
+          class="row svelte-1lxfxfd current"
           slot="item"
         >
           <div
-            class="flex-auto root svelte-1wnrcpi"
+            class="flex-auto root svelte-30dtyc"
           >
             <a
               class="flex-none"
@@ -134,7 +134,7 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
             >
               <img
                 alt="./# Films/cover.jpg"
-                class="h-16 w-16 text-xs actionable rounded-sm svelte-dtt58s"
+                class="h-16 w-16 text-xs actionable rounded-sm svelte-1psk6yi"
                 height="256"
                 loading="lazy"
                 src="./%23 Films/cover.jpg"
@@ -145,10 +145,10 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
             </a>
              
             <div
-              class="track svelte-1wnrcpi"
+              class="track svelte-30dtyc"
             >
               <span
-                class="title svelte-1wnrcpi"
+                class="title svelte-30dtyc"
               >
                 file 1
               </span>
@@ -165,7 +165,7 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
             </div>
              
             <div
-              class="duration svelte-1wnrcpi"
+              class="duration svelte-30dtyc"
             >
               3:38
             </div>
@@ -173,10 +173,10 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
           </div>
            
           <button
-            class="mx-2 iconOnly noBorder svelte-1vd9h50"
+            class="mx-2 iconOnly noBorder svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               close
             </i>
@@ -188,15 +188,15 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
          
       </li>
       <li
-        class="svelte-qra3ls"
+        class="svelte-w3rzzq"
         draggable="true"
       >
         <span
-          class="row svelte-eibfn2"
+          class="row svelte-1lxfxfd"
           slot="item"
         >
           <div
-            class="flex-auto root svelte-1wnrcpi"
+            class="flex-auto root svelte-30dtyc"
           >
             <a
               class="flex-none"
@@ -204,7 +204,7 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
             >
               <img
                 alt="./# Films/cover.jpg"
-                class="h-16 w-16 text-xs actionable rounded-sm svelte-dtt58s"
+                class="h-16 w-16 text-xs actionable rounded-sm svelte-1psk6yi"
                 height="256"
                 loading="lazy"
                 src="./%23 Films/cover.jpg"
@@ -215,10 +215,10 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
             </a>
              
             <div
-              class="track svelte-1wnrcpi"
+              class="track svelte-30dtyc"
             >
               <span
-                class="title svelte-1wnrcpi"
+                class="title svelte-30dtyc"
               >
                 file 2
               </span>
@@ -235,7 +235,7 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
             </div>
              
             <div
-              class="duration svelte-1wnrcpi"
+              class="duration svelte-30dtyc"
             >
               0:04
             </div>
@@ -243,10 +243,10 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
           </div>
            
           <button
-            class="mx-2 iconOnly noBorder svelte-1vd9h50"
+            class="mx-2 iconOnly noBorder svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               close
             </i>
@@ -258,15 +258,15 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
          
       </li>
       <li
-        class="svelte-qra3ls"
+        class="svelte-w3rzzq"
         draggable="true"
       >
         <span
-          class="row svelte-eibfn2"
+          class="row svelte-1lxfxfd"
           slot="item"
         >
           <div
-            class="flex-auto root svelte-1wnrcpi"
+            class="flex-auto root svelte-30dtyc"
           >
             <a
               class="flex-none"
@@ -274,7 +274,7 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
             >
               <img
                 alt="./cover.jpg"
-                class="h-16 w-16 text-xs actionable rounded-sm svelte-dtt58s"
+                class="h-16 w-16 text-xs actionable rounded-sm svelte-1psk6yi"
                 height="256"
                 loading="lazy"
                 src="./cover.jpg"
@@ -285,10 +285,10 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
             </a>
              
             <div
-              class="track svelte-1wnrcpi"
+              class="track svelte-30dtyc"
             >
               <span
-                class="title svelte-1wnrcpi"
+                class="title svelte-30dtyc"
               >
                 file 3
               </span>
@@ -305,7 +305,7 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
             </div>
              
             <div
-              class="duration svelte-1wnrcpi"
+              class="duration svelte-30dtyc"
             >
               0:02
             </div>
@@ -313,10 +313,10 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
           </div>
            
           <button
-            class="mx-2 iconOnly noBorder svelte-1vd9h50"
+            class="mx-2 iconOnly noBorder svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               close
             </i>
@@ -328,15 +328,15 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
          
       </li>
       <li
-        class="svelte-qra3ls"
+        class="svelte-w3rzzq"
         draggable="true"
       >
         <span
-          class="row svelte-eibfn2"
+          class="row svelte-1lxfxfd"
           slot="item"
         >
           <div
-            class="flex-auto root svelte-1wnrcpi"
+            class="flex-auto root svelte-30dtyc"
           >
             <a
               class="flex-none"
@@ -344,7 +344,7 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
             >
               <img
                 alt="./cover.jpg"
-                class="h-16 w-16 text-xs actionable rounded-sm svelte-dtt58s"
+                class="h-16 w-16 text-xs actionable rounded-sm svelte-1psk6yi"
                 height="256"
                 loading="lazy"
                 src="./cover.jpg"
@@ -355,10 +355,10 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
             </a>
              
             <div
-              class="track svelte-1wnrcpi"
+              class="track svelte-30dtyc"
             >
               <span
-                class="title svelte-1wnrcpi"
+                class="title svelte-30dtyc"
               >
                 file 4
               </span>
@@ -375,7 +375,7 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
             </div>
              
             <div
-              class="duration svelte-1wnrcpi"
+              class="duration svelte-30dtyc"
             >
               0:03
             </div>
@@ -383,10 +383,10 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
           </div>
            
           <button
-            class="mx-2 iconOnly noBorder svelte-1vd9h50"
+            class="mx-2 iconOnly noBorder svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               close
             </i>
@@ -398,15 +398,15 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
          
       </li>
       <li
-        class="svelte-qra3ls"
+        class="svelte-w3rzzq"
         draggable="true"
       >
         <span
-          class="row svelte-eibfn2"
+          class="row svelte-1lxfxfd"
           slot="item"
         >
           <div
-            class="flex-auto root svelte-1wnrcpi"
+            class="flex-auto root svelte-30dtyc"
           >
             <a
               class="flex-none"
@@ -414,7 +414,7 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
             >
               <img
                 alt="./# Films/cover.jpg"
-                class="h-16 w-16 text-xs actionable rounded-sm svelte-dtt58s"
+                class="h-16 w-16 text-xs actionable rounded-sm svelte-1psk6yi"
                 height="256"
                 loading="lazy"
                 src="./%23 Films/cover.jpg"
@@ -425,10 +425,10 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
             </a>
              
             <div
-              class="track svelte-1wnrcpi"
+              class="track svelte-30dtyc"
             >
               <span
-                class="title svelte-1wnrcpi"
+                class="title svelte-30dtyc"
               >
                 file 1
               </span>
@@ -445,7 +445,7 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
             </div>
              
             <div
-              class="duration svelte-1wnrcpi"
+              class="duration svelte-30dtyc"
             >
               3:38
             </div>
@@ -453,10 +453,10 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
           </div>
            
           <button
-            class="mx-2 iconOnly noBorder svelte-1vd9h50"
+            class="mx-2 iconOnly noBorder svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               close
             </i>
@@ -468,15 +468,15 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
          
       </li>
       <li
-        class="svelte-qra3ls"
+        class="svelte-w3rzzq"
         draggable="true"
       >
         <span
-          class="row svelte-eibfn2"
+          class="row svelte-1lxfxfd"
           slot="item"
         >
           <div
-            class="flex-auto root svelte-1wnrcpi"
+            class="flex-auto root svelte-30dtyc"
           >
             <a
               class="flex-none"
@@ -484,7 +484,7 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
             >
               <img
                 alt="./# Films/cover.jpg"
-                class="h-16 w-16 text-xs actionable rounded-sm svelte-dtt58s"
+                class="h-16 w-16 text-xs actionable rounded-sm svelte-1psk6yi"
                 height="256"
                 loading="lazy"
                 src="./%23 Films/cover.jpg"
@@ -495,10 +495,10 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
             </a>
              
             <div
-              class="track svelte-1wnrcpi"
+              class="track svelte-30dtyc"
             >
               <span
-                class="title svelte-1wnrcpi"
+                class="title svelte-30dtyc"
               >
                 file 2
               </span>
@@ -515,7 +515,7 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
             </div>
              
             <div
-              class="duration svelte-1wnrcpi"
+              class="duration svelte-30dtyc"
             >
               0:04
             </div>
@@ -523,10 +523,10 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
           </div>
            
           <button
-            class="mx-2 iconOnly noBorder svelte-1vd9h50"
+            class="mx-2 iconOnly noBorder svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               close
             </i>
@@ -538,15 +538,15 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
          
       </li>
       <li
-        class="svelte-qra3ls"
+        class="svelte-w3rzzq"
         draggable="true"
       >
         <span
-          class="row svelte-eibfn2"
+          class="row svelte-1lxfxfd"
           slot="item"
         >
           <div
-            class="flex-auto root svelte-1wnrcpi"
+            class="flex-auto root svelte-30dtyc"
           >
             <a
               class="flex-none"
@@ -554,7 +554,7 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
             >
               <img
                 alt="./cover.jpg"
-                class="h-16 w-16 text-xs actionable rounded-sm svelte-dtt58s"
+                class="h-16 w-16 text-xs actionable rounded-sm svelte-1psk6yi"
                 height="256"
                 loading="lazy"
                 src="./cover.jpg"
@@ -565,10 +565,10 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
             </a>
              
             <div
-              class="track svelte-1wnrcpi"
+              class="track svelte-30dtyc"
             >
               <span
-                class="title svelte-1wnrcpi"
+                class="title svelte-30dtyc"
               >
                 file 3
               </span>
@@ -585,7 +585,7 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
             </div>
              
             <div
-              class="duration svelte-1wnrcpi"
+              class="duration svelte-30dtyc"
             >
               0:02
             </div>
@@ -593,10 +593,10 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
           </div>
            
           <button
-            class="mx-2 iconOnly noBorder svelte-1vd9h50"
+            class="mx-2 iconOnly noBorder svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               close
             </i>
@@ -608,15 +608,15 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
          
       </li>
       <li
-        class="svelte-qra3ls"
+        class="svelte-w3rzzq"
         draggable="true"
       >
         <span
-          class="row svelte-eibfn2"
+          class="row svelte-1lxfxfd"
           slot="item"
         >
           <div
-            class="flex-auto root svelte-1wnrcpi"
+            class="flex-auto root svelte-30dtyc"
           >
             <a
               class="flex-none"
@@ -624,7 +624,7 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
             >
               <img
                 alt="./cover.jpg"
-                class="h-16 w-16 text-xs actionable rounded-sm svelte-dtt58s"
+                class="h-16 w-16 text-xs actionable rounded-sm svelte-1psk6yi"
                 height="256"
                 loading="lazy"
                 src="./cover.jpg"
@@ -635,10 +635,10 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
             </a>
              
             <div
-              class="track svelte-1wnrcpi"
+              class="track svelte-30dtyc"
             >
               <span
-                class="title svelte-1wnrcpi"
+                class="title svelte-30dtyc"
               >
                 file 4
               </span>
@@ -655,7 +655,7 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
             </div>
              
             <div
-              class="duration svelte-1wnrcpi"
+              class="duration svelte-30dtyc"
             >
               0:03
             </div>
@@ -663,10 +663,10 @@ exports[`Toolshot components/TracksQueue/TracksQueue.tools.svelte: With track li
           </div>
            
           <button
-            class="mx-2 iconOnly noBorder svelte-1vd9h50"
+            class="mx-2 iconOnly noBorder svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               close
             </i>

--- a/common/ui/src/components/TracksTable/__snapshots__/TracksTable.tools.shot
+++ b/common/ui/src/components/TracksTable/__snapshots__/TracksTable.tools.shot
@@ -5,70 +5,70 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
    
    
   <table
-    class=" svelte-14yn4jg"
+    class=" svelte-1uzdiz4"
   >
     <thead
-      class="svelte-14yn4jg"
+      class="svelte-1uzdiz4"
     >
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <th
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           #
         </th>
          
         <th
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Track
         </th>
          
         <th
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Artist
         </th>
          
         <th
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Album
         </th>
          
         <th
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           Duration
         </th>
          
         <th
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         />
       </tr>
     </thead>
      
     <tbody
-      class="svelte-14yn4jg"
+      class="svelte-1uzdiz4"
     >
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           1
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           American Money
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -88,7 +88,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -100,24 +100,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           5:32
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -133,22 +133,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           2
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Fantaisie Sign
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -168,7 +168,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -180,24 +180,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           3:35
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -213,22 +213,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           3
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Don't Bother None
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -248,7 +248,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -260,24 +260,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           3:45
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -293,22 +293,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           4
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Vitamin A
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -328,7 +328,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -340,24 +340,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           4:41
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -373,22 +373,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           5
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           LIVE in Baghdad
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -408,7 +408,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -420,24 +420,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           2:59
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -453,22 +453,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           6
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Cats on Mars
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -488,7 +488,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -500,24 +500,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           0:07
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -533,22 +533,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           7
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Want it All Back
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -568,7 +568,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -580,24 +580,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           3:51
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -613,22 +613,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           8
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Bindy
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -648,7 +648,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -660,24 +660,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           0:15
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -693,22 +693,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           9
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           You Make Me Coo
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -728,7 +728,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -740,24 +740,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           3:14
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -773,22 +773,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           10
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Vitamin B
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -808,7 +808,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -820,24 +820,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           4:06
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -853,22 +853,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           11
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Green Bird
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -888,7 +888,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -900,24 +900,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           2:33
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -933,22 +933,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           12
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           ELM
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -968,7 +968,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -980,24 +980,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           6:55
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -1013,22 +1013,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           13
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Vitamin C
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1048,7 +1048,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1060,24 +1060,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           5:24
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -1093,22 +1093,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           14
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Gateway
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1128,7 +1128,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1140,24 +1140,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           0:16
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -1173,22 +1173,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           15
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           The Singing Sea
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1208,7 +1208,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1220,24 +1220,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           6:41
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -1253,22 +1253,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           16
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           The Egg and You!
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1288,7 +1288,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1300,24 +1300,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           4:47
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -1333,22 +1333,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           17
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Forever Broke
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1368,7 +1368,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1380,24 +1380,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           1:36
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -1413,22 +1413,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           18
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Power of Kungfu Remix
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1448,7 +1448,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1460,24 +1460,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Default 1`] =
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           2:22
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -1503,70 +1503,70 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
    
    
   <table
-    class=" svelte-14yn4jg"
+    class=" svelte-1uzdiz4"
   >
     <thead
-      class="svelte-14yn4jg"
+      class="svelte-1uzdiz4"
     >
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <th
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           #
         </th>
          
         <th
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Track
         </th>
          
         <th
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Artist
         </th>
          
         <th
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Album
         </th>
          
         <th
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           Duration
         </th>
          
         <th
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         />
       </tr>
     </thead>
      
     <tbody
-      class="svelte-14yn4jg"
+      class="svelte-1uzdiz4"
     >
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           1
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           American Money
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1586,7 +1586,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1598,24 +1598,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           5:32
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -1631,22 +1631,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           2
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Fantaisie Sign
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1666,7 +1666,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1678,24 +1678,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           3:35
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -1711,22 +1711,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           3
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Don't Bother None
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1746,7 +1746,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1758,24 +1758,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           3:45
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -1791,22 +1791,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
          
       </tr>
       <tr
-        class="svelte-14yn4jg current"
+        class="svelte-1uzdiz4 current"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           4
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Vitamin A
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1826,7 +1826,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1838,24 +1838,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           4:41
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -1871,22 +1871,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           5
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           LIVE in Baghdad
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1906,7 +1906,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1918,24 +1918,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           2:59
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -1951,22 +1951,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           6
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Cats on Mars
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1986,7 +1986,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -1998,24 +1998,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           0:07
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -2031,22 +2031,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           7
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Want it All Back
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -2066,7 +2066,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -2078,24 +2078,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           3:51
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -2111,22 +2111,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           8
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Bindy
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -2146,7 +2146,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -2158,24 +2158,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           0:15
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -2191,22 +2191,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           9
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           You Make Me Coo
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -2226,7 +2226,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -2238,24 +2238,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           3:14
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -2271,22 +2271,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           10
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Vitamin B
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -2306,7 +2306,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -2318,24 +2318,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           4:06
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -2351,22 +2351,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           11
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Green Bird
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -2386,7 +2386,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -2398,24 +2398,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           2:33
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -2431,22 +2431,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           12
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           ELM
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -2466,7 +2466,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -2478,24 +2478,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           6:55
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -2511,22 +2511,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           13
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Vitamin C
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -2546,7 +2546,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -2558,24 +2558,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           5:24
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -2591,22 +2591,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           14
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Gateway
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -2626,7 +2626,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -2638,24 +2638,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           0:16
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -2671,22 +2671,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           15
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           The Singing Sea
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -2706,7 +2706,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -2718,24 +2718,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           6:41
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -2751,22 +2751,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           16
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           The Egg and You!
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -2786,7 +2786,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -2798,24 +2798,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           4:47
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -2831,22 +2831,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           17
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Forever Broke
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -2866,7 +2866,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -2878,24 +2878,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           1:36
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -2911,22 +2911,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           18
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           Power of Kungfu Remix
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -2946,7 +2946,7 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="col-span-3 svelte-14yn4jg"
+          class="col-span-3 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -2958,24 +2958,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: With current 
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           2:22
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -3001,65 +3001,65 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
    
    
   <table
-    class=" svelte-14yn4jg"
+    class=" svelte-1uzdiz4"
   >
     <thead
-      class="svelte-14yn4jg"
+      class="svelte-1uzdiz4"
     >
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <th
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           #
         </th>
          
         <th
-          class="col-span-5 svelte-14yn4jg"
+          class="col-span-5 svelte-1uzdiz4"
         >
           Track
         </th>
          
         <th
-          class="col-span-4 svelte-14yn4jg"
+          class="col-span-4 svelte-1uzdiz4"
         >
           Artist
         </th>
          
          
         <th
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           Duration
         </th>
          
         <th
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         />
       </tr>
     </thead>
      
     <tbody
-      class="svelte-14yn4jg"
+      class="svelte-1uzdiz4"
     >
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           1
         </td>
          
         <td
-          class="col-span-5 svelte-14yn4jg"
+          class="col-span-5 svelte-1uzdiz4"
         >
           American Money
         </td>
          
         <td
-          class="col-span-4 svelte-14yn4jg"
+          class="col-span-4 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -3080,24 +3080,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           5:32
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -3113,22 +3113,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           2
         </td>
          
         <td
-          class="col-span-5 svelte-14yn4jg"
+          class="col-span-5 svelte-1uzdiz4"
         >
           Fantaisie Sign
         </td>
          
         <td
-          class="col-span-4 svelte-14yn4jg"
+          class="col-span-4 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -3149,24 +3149,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           3:35
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -3182,22 +3182,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           3
         </td>
          
         <td
-          class="col-span-5 svelte-14yn4jg"
+          class="col-span-5 svelte-1uzdiz4"
         >
           Don't Bother None
         </td>
          
         <td
-          class="col-span-4 svelte-14yn4jg"
+          class="col-span-4 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -3218,24 +3218,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           3:45
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -3251,22 +3251,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           4
         </td>
          
         <td
-          class="col-span-5 svelte-14yn4jg"
+          class="col-span-5 svelte-1uzdiz4"
         >
           Vitamin A
         </td>
          
         <td
-          class="col-span-4 svelte-14yn4jg"
+          class="col-span-4 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -3287,24 +3287,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           4:41
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -3320,22 +3320,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           5
         </td>
          
         <td
-          class="col-span-5 svelte-14yn4jg"
+          class="col-span-5 svelte-1uzdiz4"
         >
           LIVE in Baghdad
         </td>
          
         <td
-          class="col-span-4 svelte-14yn4jg"
+          class="col-span-4 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -3356,24 +3356,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           2:59
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -3389,22 +3389,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           6
         </td>
          
         <td
-          class="col-span-5 svelte-14yn4jg"
+          class="col-span-5 svelte-1uzdiz4"
         >
           Cats on Mars
         </td>
          
         <td
-          class="col-span-4 svelte-14yn4jg"
+          class="col-span-4 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -3425,24 +3425,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           0:07
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -3458,22 +3458,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           7
         </td>
          
         <td
-          class="col-span-5 svelte-14yn4jg"
+          class="col-span-5 svelte-1uzdiz4"
         >
           Want it All Back
         </td>
          
         <td
-          class="col-span-4 svelte-14yn4jg"
+          class="col-span-4 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -3494,24 +3494,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           3:51
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -3527,22 +3527,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           8
         </td>
          
         <td
-          class="col-span-5 svelte-14yn4jg"
+          class="col-span-5 svelte-1uzdiz4"
         >
           Bindy
         </td>
          
         <td
-          class="col-span-4 svelte-14yn4jg"
+          class="col-span-4 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -3563,24 +3563,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           0:15
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -3596,22 +3596,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           9
         </td>
          
         <td
-          class="col-span-5 svelte-14yn4jg"
+          class="col-span-5 svelte-1uzdiz4"
         >
           You Make Me Coo
         </td>
          
         <td
-          class="col-span-4 svelte-14yn4jg"
+          class="col-span-4 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -3632,24 +3632,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           3:14
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -3665,22 +3665,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           10
         </td>
          
         <td
-          class="col-span-5 svelte-14yn4jg"
+          class="col-span-5 svelte-1uzdiz4"
         >
           Vitamin B
         </td>
          
         <td
-          class="col-span-4 svelte-14yn4jg"
+          class="col-span-4 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -3701,24 +3701,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           4:06
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -3734,22 +3734,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           11
         </td>
          
         <td
-          class="col-span-5 svelte-14yn4jg"
+          class="col-span-5 svelte-1uzdiz4"
         >
           Green Bird
         </td>
          
         <td
-          class="col-span-4 svelte-14yn4jg"
+          class="col-span-4 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -3770,24 +3770,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           2:33
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -3803,22 +3803,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           12
         </td>
          
         <td
-          class="col-span-5 svelte-14yn4jg"
+          class="col-span-5 svelte-1uzdiz4"
         >
           ELM
         </td>
          
         <td
-          class="col-span-4 svelte-14yn4jg"
+          class="col-span-4 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -3839,24 +3839,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           6:55
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -3872,22 +3872,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           13
         </td>
          
         <td
-          class="col-span-5 svelte-14yn4jg"
+          class="col-span-5 svelte-1uzdiz4"
         >
           Vitamin C
         </td>
          
         <td
-          class="col-span-4 svelte-14yn4jg"
+          class="col-span-4 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -3908,24 +3908,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           5:24
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -3941,22 +3941,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           14
         </td>
          
         <td
-          class="col-span-5 svelte-14yn4jg"
+          class="col-span-5 svelte-1uzdiz4"
         >
           Gateway
         </td>
          
         <td
-          class="col-span-4 svelte-14yn4jg"
+          class="col-span-4 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -3977,24 +3977,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           0:16
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -4010,22 +4010,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           15
         </td>
          
         <td
-          class="col-span-5 svelte-14yn4jg"
+          class="col-span-5 svelte-1uzdiz4"
         >
           The Singing Sea
         </td>
          
         <td
-          class="col-span-4 svelte-14yn4jg"
+          class="col-span-4 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -4046,24 +4046,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           6:41
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -4079,22 +4079,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           16
         </td>
          
         <td
-          class="col-span-5 svelte-14yn4jg"
+          class="col-span-5 svelte-1uzdiz4"
         >
           The Egg and You!
         </td>
          
         <td
-          class="col-span-4 svelte-14yn4jg"
+          class="col-span-4 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -4115,24 +4115,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           4:47
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -4148,22 +4148,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           17
         </td>
          
         <td
-          class="col-span-5 svelte-14yn4jg"
+          class="col-span-5 svelte-1uzdiz4"
         >
           Forever Broke
         </td>
          
         <td
-          class="col-span-4 svelte-14yn4jg"
+          class="col-span-4 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -4184,24 +4184,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           1:36
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>
@@ -4217,22 +4217,22 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
       </tr>
       <tr
-        class="svelte-14yn4jg"
+        class="svelte-1uzdiz4"
       >
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           18
         </td>
          
         <td
-          class="col-span-5 svelte-14yn4jg"
+          class="col-span-5 svelte-1uzdiz4"
         >
           Power of Kungfu Remix
         </td>
          
         <td
-          class="col-span-4 svelte-14yn4jg"
+          class="col-span-4 svelte-1uzdiz4"
         >
           <a
             class="underlined"
@@ -4253,24 +4253,24 @@ exports[`Toolshot components/TracksTable/TracksTable.tools.svelte: Without abum 
          
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           2:22
         </td>
          
         <td
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="iconOnly noBorder svelte-1vd9h50"
+              class="iconOnly noBorder svelte-1e4q28k"
             >
               <i
-                class="material-icons svelte-1vd9h50"
+                class="material-icons svelte-1e4q28k"
               >
                 more_vert
               </i>

--- a/common/ui/src/routes/__snapshots__/album.tools.shot
+++ b/common/ui/src/routes/__snapshots__/album.tools.shot
@@ -3,50 +3,50 @@
 exports[`Toolshot routes/album.tools.svelte: Views/Albums 1`] = `
 <div>
   <section
-    class="svelte-117lkw2"
+    class="svelte-ojckha"
     style="animation: __svelte_185617033_0 200ms linear 0ms 1 both;"
   >
     <header
-      class=" svelte-8800qh"
+      class=" svelte-t58ezf"
       style="--image: url(../images/valentino-funghi-MEcxLZ8ENV8-unsplash.jpg); --shade-color: rgba(0, 0, 0, 0.7); --bgPosition: center 25%;"
     >
       <h1
-        class="svelte-8800qh"
+        class="svelte-t58ezf"
       >
         3 albums
       </h1>
     </header>
      
     <div
-      class="svelte-117lkw2"
+      class="svelte-ojckha"
     >
       <span
-        class="svelte-117lkw2"
+        class="svelte-ojckha"
         id="firstAlbum"
       >
          
         <span
-          class="svelte-9e8ghi"
+          class="svelte-4r86n"
           role="article"
         >
           <div
-            class="content svelte-9e8ghi"
+            class="content svelte-4r86n"
           >
             <span
-              class="artwork svelte-9e8ghi"
+              class="artwork svelte-4r86n"
             >
               <img
-                class="h-full w-full rounded-sm hidden svelte-dtt58s"
+                class="h-full w-full rounded-sm hidden svelte-1psk6yi"
                 height="256"
                 loading="lazy"
                 width="256"
               />
                
               <span
-                class="h-full w-full svelte-dtt58s rounded-sm"
+                class="h-full w-full svelte-1psk6yi rounded-sm"
               >
                 <i
-                  class="material-icons svelte-dtt58s"
+                  class="material-icons svelte-1psk6yi"
                 >
                   music_note
                 </i>
@@ -55,15 +55,15 @@ exports[`Toolshot routes/album.tools.svelte: Views/Albums 1`] = `
             </span>
              
             <p
-              class="controls svelte-9e8ghi"
+              class="controls svelte-4r86n"
             >
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="play"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   play_arrow
                 </i>
@@ -73,11 +73,11 @@ exports[`Toolshot routes/album.tools.svelte: Views/Albums 1`] = `
               </button>
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="enqueue"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   playlist_add
                 </i>
@@ -89,16 +89,16 @@ exports[`Toolshot routes/album.tools.svelte: Views/Albums 1`] = `
           </div>
            
           <header
-            class="svelte-9e8ghi"
+            class="svelte-4r86n"
           >
             <h3
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
             >
               100 Best Karajan
             </h3>
              
             <h4
-              class="svelte-1vmk98n"
+              class="svelte-rw2hde"
               slot="details"
             >
               by 
@@ -157,22 +157,22 @@ exports[`Toolshot routes/album.tools.svelte: Views/Albums 1`] = `
          
       </span>
       <span
-        class="svelte-117lkw2"
+        class="svelte-ojckha"
       >
          
         <span
-          class="svelte-9e8ghi"
+          class="svelte-4r86n"
           role="article"
         >
           <div
-            class="content svelte-9e8ghi"
+            class="content svelte-4r86n"
           >
             <span
-              class="artwork svelte-9e8ghi"
+              class="artwork svelte-4r86n"
             >
               <img
                 alt="cover.jpg"
-                class="h-full w-full rounded-sm svelte-dtt58s"
+                class="h-full w-full rounded-sm svelte-1psk6yi"
                 height="256"
                 loading="lazy"
                 src="cover.jpg"
@@ -183,15 +183,15 @@ exports[`Toolshot routes/album.tools.svelte: Views/Albums 1`] = `
             </span>
              
             <p
-              class="controls svelte-9e8ghi"
+              class="controls svelte-4r86n"
             >
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="play"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   play_arrow
                 </i>
@@ -201,11 +201,11 @@ exports[`Toolshot routes/album.tools.svelte: Views/Albums 1`] = `
               </button>
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="enqueue"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   playlist_add
                 </i>
@@ -217,16 +217,16 @@ exports[`Toolshot routes/album.tools.svelte: Views/Albums 1`] = `
           </div>
            
           <header
-            class="svelte-9e8ghi"
+            class="svelte-4r86n"
           >
             <h3
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
             >
               Black Orpheus
             </h3>
              
             <h4
-              class="svelte-1vmk98n"
+              class="svelte-rw2hde"
               slot="details"
             >
               by 
@@ -245,31 +245,31 @@ exports[`Toolshot routes/album.tools.svelte: Views/Albums 1`] = `
          
       </span>
       <span
-        class="svelte-117lkw2"
+        class="svelte-ojckha"
       >
          
         <span
-          class="svelte-9e8ghi"
+          class="svelte-4r86n"
           role="article"
         >
           <div
-            class="content svelte-9e8ghi"
+            class="content svelte-4r86n"
           >
             <span
-              class="artwork svelte-9e8ghi"
+              class="artwork svelte-4r86n"
             >
               <img
-                class="h-full w-full rounded-sm hidden svelte-dtt58s"
+                class="h-full w-full rounded-sm hidden svelte-1psk6yi"
                 height="256"
                 loading="lazy"
                 width="256"
               />
                
               <span
-                class="h-full w-full svelte-dtt58s rounded-sm"
+                class="h-full w-full svelte-1psk6yi rounded-sm"
               >
                 <i
-                  class="material-icons svelte-dtt58s"
+                  class="material-icons svelte-1psk6yi"
                 >
                   music_note
                 </i>
@@ -278,15 +278,15 @@ exports[`Toolshot routes/album.tools.svelte: Views/Albums 1`] = `
             </span>
              
             <p
-              class="controls svelte-9e8ghi"
+              class="controls svelte-4r86n"
             >
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="play"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   play_arrow
                 </i>
@@ -296,11 +296,11 @@ exports[`Toolshot routes/album.tools.svelte: Views/Albums 1`] = `
               </button>
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="enqueue"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   playlist_add
                 </i>
@@ -312,16 +312,16 @@ exports[`Toolshot routes/album.tools.svelte: Views/Albums 1`] = `
           </div>
            
           <header
-            class="svelte-9e8ghi"
+            class="svelte-4r86n"
           >
             <h3
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
             >
               Distant Worlds - Music from Final Fantasy
             </h3>
              
             <h4
-              class="svelte-1vmk98n"
+              class="svelte-rw2hde"
               slot="details"
             >
               by 

--- a/common/ui/src/routes/__snapshots__/artist.tools.shot
+++ b/common/ui/src/routes/__snapshots__/artist.tools.shot
@@ -3,49 +3,49 @@
 exports[`Toolshot routes/artist.tools.svelte: Views/Artist 1`] = `
 <div>
   <section
-    class="svelte-117lkw2"
+    class="svelte-ojckha"
     style="animation: __svelte_185617033_0 200ms linear 0ms 1 both;"
   >
     <header
-      class=" svelte-8800qh"
+      class=" svelte-t58ezf"
       style="--image: url(../images/larisa-birta-slbOcNlWNHA-unsplash.jpg); --shade-color: rgba(0, 0, 0, 0.7); --bgPosition: center;"
     >
       <h1
-        class="svelte-8800qh"
+        class="svelte-t58ezf"
       >
         3 artists
       </h1>
     </header>
      
     <div
-      class="svelte-117lkw2"
+      class="svelte-ojckha"
     >
       <span
-        class="svelte-117lkw2"
+        class="svelte-ojckha"
       >
          
         <span
-          class="svelte-9e8ghi"
+          class="svelte-4r86n"
           role="article"
         >
           <div
-            class="content svelte-9e8ghi"
+            class="content svelte-4r86n"
           >
             <span
-              class="artwork svelte-9e8ghi"
+              class="artwork svelte-4r86n"
             >
               <img
-                class="h-full w-full rounded-full hidden svelte-dtt58s"
+                class="h-full w-full rounded-full hidden svelte-1psk6yi"
                 height="256"
                 loading="lazy"
                 width="256"
               />
                
               <span
-                class="h-full w-full svelte-dtt58s rounded-full"
+                class="h-full w-full svelte-1psk6yi rounded-full"
               >
                 <i
-                  class="material-icons svelte-dtt58s"
+                  class="material-icons svelte-1psk6yi"
                 >
                   person
                 </i>
@@ -54,15 +54,15 @@ exports[`Toolshot routes/artist.tools.svelte: Views/Artist 1`] = `
             </span>
              
             <p
-              class="controls svelte-9e8ghi"
+              class="controls svelte-4r86n"
             >
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="play"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   play_arrow
                 </i>
@@ -72,11 +72,11 @@ exports[`Toolshot routes/artist.tools.svelte: Views/Artist 1`] = `
               </button>
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="enqueue"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   playlist_add
                 </i>
@@ -88,16 +88,16 @@ exports[`Toolshot routes/artist.tools.svelte: Views/Artist 1`] = `
           </div>
            
           <header
-            class="svelte-9e8ghi"
+            class="svelte-4r86n"
           >
             <h3
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
             >
               Ludwig Van Beethoven
             </h3>
              
             <h4
-              class="svelte-1vmk98n"
+              class="svelte-rw2hde"
               slot="details"
             >
               1 album
@@ -107,22 +107,22 @@ exports[`Toolshot routes/artist.tools.svelte: Views/Artist 1`] = `
          
       </span>
       <span
-        class="svelte-117lkw2"
+        class="svelte-ojckha"
       >
          
         <span
-          class="svelte-9e8ghi"
+          class="svelte-4r86n"
           role="article"
         >
           <div
-            class="content svelte-9e8ghi"
+            class="content svelte-4r86n"
           >
             <span
-              class="artwork svelte-9e8ghi"
+              class="artwork svelte-4r86n"
             >
               <img
                 alt="avatar.jpg"
-                class="h-full w-full rounded-full svelte-dtt58s"
+                class="h-full w-full rounded-full svelte-1psk6yi"
                 height="256"
                 loading="lazy"
                 src="avatar.jpg"
@@ -133,15 +133,15 @@ exports[`Toolshot routes/artist.tools.svelte: Views/Artist 1`] = `
             </span>
              
             <p
-              class="controls svelte-9e8ghi"
+              class="controls svelte-4r86n"
             >
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="play"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   play_arrow
                 </i>
@@ -151,11 +151,11 @@ exports[`Toolshot routes/artist.tools.svelte: Views/Artist 1`] = `
               </button>
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="enqueue"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   playlist_add
                 </i>
@@ -167,16 +167,16 @@ exports[`Toolshot routes/artist.tools.svelte: Views/Artist 1`] = `
           </div>
            
           <header
-            class="svelte-9e8ghi"
+            class="svelte-4r86n"
           >
             <h3
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
             >
               Mademoiselle K
             </h3>
              
             <h4
-              class="svelte-1vmk98n"
+              class="svelte-rw2hde"
               slot="details"
             >
               2 albums
@@ -186,31 +186,31 @@ exports[`Toolshot routes/artist.tools.svelte: Views/Artist 1`] = `
          
       </span>
       <span
-        class="svelte-117lkw2"
+        class="svelte-ojckha"
       >
          
         <span
-          class="svelte-9e8ghi"
+          class="svelte-4r86n"
           role="article"
         >
           <div
-            class="content svelte-9e8ghi"
+            class="content svelte-4r86n"
           >
             <span
-              class="artwork svelte-9e8ghi"
+              class="artwork svelte-4r86n"
             >
               <img
-                class="h-full w-full rounded-full hidden svelte-dtt58s"
+                class="h-full w-full rounded-full hidden svelte-1psk6yi"
                 height="256"
                 loading="lazy"
                 width="256"
               />
                
               <span
-                class="h-full w-full svelte-dtt58s rounded-full"
+                class="h-full w-full svelte-1psk6yi rounded-full"
               >
                 <i
-                  class="material-icons svelte-dtt58s"
+                  class="material-icons svelte-1psk6yi"
                 >
                   person
                 </i>
@@ -219,15 +219,15 @@ exports[`Toolshot routes/artist.tools.svelte: Views/Artist 1`] = `
             </span>
              
             <p
-              class="controls svelte-9e8ghi"
+              class="controls svelte-4r86n"
             >
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="play"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   play_arrow
                 </i>
@@ -237,11 +237,11 @@ exports[`Toolshot routes/artist.tools.svelte: Views/Artist 1`] = `
               </button>
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="enqueue"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   playlist_add
                 </i>
@@ -253,16 +253,16 @@ exports[`Toolshot routes/artist.tools.svelte: Views/Artist 1`] = `
           </div>
            
           <header
-            class="svelte-9e8ghi"
+            class="svelte-4r86n"
           >
             <h3
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
             >
               Yoko Kanno and the Seatbelts
             </h3>
              
             <h4
-              class="svelte-1vmk98n"
+              class="svelte-rw2hde"
               slot="details"
             >
               9 albums

--- a/common/ui/src/routes/__snapshots__/playlist.tools.shot
+++ b/common/ui/src/routes/__snapshots__/playlist.tools.shot
@@ -3,48 +3,48 @@
 exports[`Toolshot routes/playlist.tools.svelte: Views/Playlist 1`] = `
 <div>
   <section
-    class="svelte-6l325s"
+    class="svelte-14jiyy0"
     style="animation: __svelte_185617033_0 200ms linear 0ms 1 both;"
   >
     <header
-      class=" svelte-8800qh"
+      class=" svelte-t58ezf"
       style="--image: url(../images/david-villasana-YNJGB-_Vlgw-unsplash.jpg); --shade-color: rgba(0, 0, 0, 0.7); --bgPosition: center 46%;"
     >
       <h1
-        class="svelte-8800qh"
+        class="svelte-t58ezf"
       >
         3 playlists
       </h1>
     </header>
      
     <div
-      class="svelte-6l325s"
+      class="svelte-14jiyy0"
     >
       <span
-        class="svelte-6l325s"
+        class="svelte-14jiyy0"
       >
          
         <span
-          class="svelte-9e8ghi overlay"
+          class="svelte-4r86n overlay"
           role="article"
         >
           <div
-            class="content svelte-9e8ghi"
+            class="content svelte-4r86n"
           >
             <span
-              class="artwork svelte-9e8ghi"
+              class="artwork svelte-4r86n"
             />
              
             <p
-              class="controls svelte-9e8ghi"
+              class="controls svelte-4r86n"
             >
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="play"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   play_arrow
                 </i>
@@ -54,11 +54,11 @@ exports[`Toolshot routes/playlist.tools.svelte: Views/Playlist 1`] = `
               </button>
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="enqueue"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   playlist_add
                 </i>
@@ -70,10 +70,10 @@ exports[`Toolshot routes/playlist.tools.svelte: Views/Playlist 1`] = `
           </div>
            
           <header
-            class="svelte-9e8ghi"
+            class="svelte-4r86n"
           >
             <h3
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
             >
               My favourites
             </h3>
@@ -88,30 +88,30 @@ exports[`Toolshot routes/playlist.tools.svelte: Views/Playlist 1`] = `
          
       </span>
       <span
-        class="svelte-6l325s"
+        class="svelte-14jiyy0"
       >
          
         <span
-          class="svelte-9e8ghi overlay"
+          class="svelte-4r86n overlay"
           role="article"
         >
           <div
-            class="content svelte-9e8ghi"
+            class="content svelte-4r86n"
           >
             <span
-              class="artwork svelte-9e8ghi"
+              class="artwork svelte-4r86n"
             />
              
             <p
-              class="controls svelte-9e8ghi"
+              class="controls svelte-4r86n"
             >
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="play"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   play_arrow
                 </i>
@@ -121,11 +121,11 @@ exports[`Toolshot routes/playlist.tools.svelte: Views/Playlist 1`] = `
               </button>
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="enqueue"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   playlist_add
                 </i>
@@ -137,10 +137,10 @@ exports[`Toolshot routes/playlist.tools.svelte: Views/Playlist 1`] = `
           </div>
            
           <header
-            class="svelte-9e8ghi"
+            class="svelte-4r86n"
           >
             <h3
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
             >
               Rock
             </h3>
@@ -155,30 +155,30 @@ exports[`Toolshot routes/playlist.tools.svelte: Views/Playlist 1`] = `
          
       </span>
       <span
-        class="svelte-6l325s"
+        class="svelte-14jiyy0"
       >
          
         <span
-          class="svelte-9e8ghi overlay"
+          class="svelte-4r86n overlay"
           role="article"
         >
           <div
-            class="content svelte-9e8ghi"
+            class="content svelte-4r86n"
           >
             <span
-              class="artwork svelte-9e8ghi"
+              class="artwork svelte-4r86n"
             />
              
             <p
-              class="controls svelte-9e8ghi"
+              class="controls svelte-4r86n"
             >
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="play"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   play_arrow
                 </i>
@@ -188,11 +188,11 @@ exports[`Toolshot routes/playlist.tools.svelte: Views/Playlist 1`] = `
               </button>
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="enqueue"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   playlist_add
                 </i>
@@ -204,10 +204,10 @@ exports[`Toolshot routes/playlist.tools.svelte: Views/Playlist 1`] = `
           </div>
            
           <header
-            class="svelte-9e8ghi"
+            class="svelte-4r86n"
           >
             <h3
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
             >
               Slows
             </h3>

--- a/common/ui/src/routes/__snapshots__/settings.tools.shot
+++ b/common/ui/src/routes/__snapshots__/settings.tools.shot
@@ -4,40 +4,40 @@ exports[`Toolshot routes/settings.tools.svelte: Views/Settings 1`] = `
 <span>
   <section>
     <header
-      class=" svelte-8800qh"
+      class=" svelte-t58ezf"
       style="--image: url(../images/rima-kruciene-gpKe3hmIawg-unsplash.jpg); --shade-color: rgba(0, 0, 0, 0.7); --bgPosition: center 65%;"
     >
       <h1
-        class="svelte-8800qh"
+        class="svelte-t58ezf"
       >
         Settings
       </h1>
     </header>
      
     <article
-      class="svelte-1b4svz0"
+      class="svelte-n00d3j"
     >
       <h4
-        class=" svelte-yxo9fq"
+        class=" svelte-177xz1h"
       >
         Music folders
       </h4>
        
       <ul>
         <li
-          class="svelte-1b4svz0"
+          class="svelte-n00d3j"
         >
           <span
-            class="svelte-1b4svz0"
+            class="svelte-n00d3j"
           >
             /home/music
           </span>
            
           <button
-            class="iconOnly noBorder svelte-1vd9h50"
+            class="iconOnly noBorder svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               close
             </i>
@@ -48,19 +48,19 @@ exports[`Toolshot routes/settings.tools.svelte: Views/Settings 1`] = `
            
         </li>
         <li
-          class="svelte-1b4svz0"
+          class="svelte-n00d3j"
         >
           <span
-            class="svelte-1b4svz0"
+            class="svelte-n00d3j"
           >
             /home/movies
           </span>
            
           <button
-            class="iconOnly noBorder svelte-1vd9h50"
+            class="iconOnly noBorder svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               close
             </i>
@@ -73,14 +73,14 @@ exports[`Toolshot routes/settings.tools.svelte: Views/Settings 1`] = `
       </ul>
        
       <span
-        class="controlContainer svelte-1b4svz0"
+        class="controlContainer svelte-n00d3j"
         id="folder"
       >
         <button
-          class="svelte-1vd9h50"
+          class="svelte-1e4q28k"
         >
           <i
-            class="material-icons svelte-1vd9h50"
+            class="material-icons svelte-1e4q28k"
           >
             folder
           </i>
@@ -95,35 +95,35 @@ exports[`Toolshot routes/settings.tools.svelte: Views/Settings 1`] = `
     </article>
      
     <article
-      class="svelte-1b4svz0"
+      class="svelte-n00d3j"
     >
       <h4
-        class=" svelte-yxo9fq"
+        class=" svelte-177xz1h"
       >
         Interface settings
       </h4>
        
       <p
-        class="svelte-1b4svz0"
+        class="svelte-n00d3j"
       >
         <label
-          class="svelte-1b4svz0"
+          class="svelte-n00d3j"
           for="locale"
         >
           Language:
         </label>
          
         <span
-          class="controlContainer svelte-1b4svz0"
+          class="controlContainer svelte-n00d3j"
           id="locale"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="svelte-1vd9h50"
+              class="svelte-1e4q28k"
             >
                
               <span>
@@ -131,7 +131,7 @@ exports[`Toolshot routes/settings.tools.svelte: Views/Settings 1`] = `
               </span>
                
               <i
-                class="material-icons arrow svelte-1x6dshm"
+                class="material-icons arrow svelte-11prmkk"
               >
                 arrow_drop_down
               </i>
@@ -145,10 +145,10 @@ exports[`Toolshot routes/settings.tools.svelte: Views/Settings 1`] = `
       </p>
        
       <p
-        class="svelte-1b4svz0"
+        class="svelte-n00d3j"
       >
         <label
-          class="svelte-1b4svz0"
+          class="svelte-n00d3j"
           for="play-behaviour"
         >
           Button 
@@ -161,16 +161,16 @@ exports[`Toolshot routes/settings.tools.svelte: Views/Settings 1`] = `
         </label>
          
         <span
-          class="controlContainer svelte-1b4svz0"
+          class="controlContainer svelte-n00d3j"
           id="play-behaviour"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="svelte-1vd9h50"
+              class="svelte-1e4q28k"
             >
                
               <span>
@@ -178,7 +178,7 @@ exports[`Toolshot routes/settings.tools.svelte: Views/Settings 1`] = `
               </span>
                
               <i
-                class="material-icons arrow svelte-1x6dshm"
+                class="material-icons arrow svelte-11prmkk"
               >
                 arrow_drop_down
               </i>
@@ -192,26 +192,26 @@ exports[`Toolshot routes/settings.tools.svelte: Views/Settings 1`] = `
       </p>
        
       <p
-        class="svelte-1b4svz0"
+        class="svelte-n00d3j"
       >
         <label
-          class="svelte-1b4svz0"
+          class="svelte-n00d3j"
           for="click-behaviour"
         >
           Simple click:
         </label>
          
         <span
-          class="controlContainer svelte-1b4svz0"
+          class="controlContainer svelte-n00d3j"
           id="click-behaviour"
         >
           <span
             aria-expanded="false"
             aria-haspopup="menu"
-            class="wrapper svelte-1x6dshm"
+            class="wrapper svelte-11prmkk"
           >
             <button
-              class="svelte-1vd9h50"
+              class="svelte-1e4q28k"
             >
                
               <span>
@@ -219,7 +219,7 @@ exports[`Toolshot routes/settings.tools.svelte: Views/Settings 1`] = `
               </span>
                
               <i
-                class="material-icons arrow svelte-1x6dshm"
+                class="material-icons arrow svelte-11prmkk"
               >
                 arrow_drop_down
               </i>
@@ -237,16 +237,16 @@ exports[`Toolshot routes/settings.tools.svelte: Views/Settings 1`] = `
     </article>
      
     <article
-      class="svelte-1b4svz0"
+      class="svelte-n00d3j"
     >
       <h4
-        class=" svelte-yxo9fq"
+        class=" svelte-177xz1h"
       >
         AudioDB data provider
       </h4>
        
       <div
-        class="instructions svelte-1b4svz0"
+        class="instructions svelte-n00d3j"
       >
         <p>
           TheAudioDB is a community Database of audio artwork and data with a JSON API. Mélodie can use it for album covers and artist artwork, but it needs an API key.
@@ -274,7 +274,7 @@ exports[`Toolshot routes/settings.tools.svelte: Views/Settings 1`] = `
       </div>
        
       <label
-        class="svelte-1b4svz0"
+        class="svelte-n00d3j"
         for="audiodb-key"
       >
         Key:
@@ -282,15 +282,15 @@ exports[`Toolshot routes/settings.tools.svelte: Views/Settings 1`] = `
       </label>
        
       <span
-        class="controlContainer svelte-1b4svz0"
+        class="controlContainer svelte-n00d3j"
         id="audiodb-key"
       >
         <span
-          class="settings-input svelte-1crflxh"
+          class="settings-input svelte-1rbj4tt"
         >
            
           <input
-            class="svelte-1crflxh"
+            class="svelte-1rbj4tt"
             placeholder="Paste your key here"
             type="text"
           />
@@ -299,16 +299,16 @@ exports[`Toolshot routes/settings.tools.svelte: Views/Settings 1`] = `
     </article>
      
     <article
-      class="svelte-1b4svz0"
+      class="svelte-n00d3j"
     >
       <h4
-        class=" svelte-yxo9fq"
+        class=" svelte-177xz1h"
       >
         Discogs data provider
       </h4>
        
       <div
-        class="instructions svelte-1b4svz0"
+        class="instructions svelte-n00d3j"
       >
         <p>
           Discogs is on a mission to build the biggest and most comprehensive music database and marketplace. Mélodie can use it for album covers and artist artwork, but it needs an access token.
@@ -336,7 +336,7 @@ exports[`Toolshot routes/settings.tools.svelte: Views/Settings 1`] = `
       </div>
        
       <label
-        class="svelte-1b4svz0"
+        class="svelte-n00d3j"
         for="discogs-token"
       >
         Access token:
@@ -344,15 +344,15 @@ exports[`Toolshot routes/settings.tools.svelte: Views/Settings 1`] = `
       </label>
        
       <span
-        class="controlContainer svelte-1b4svz0"
+        class="controlContainer svelte-n00d3j"
         id="discogs-token"
       >
         <span
-          class="settings-input svelte-1crflxh"
+          class="settings-input svelte-1rbj4tt"
         >
            
           <input
-            class="svelte-1crflxh"
+            class="svelte-1rbj4tt"
             placeholder="Paste your token here"
             type="text"
           />
@@ -361,31 +361,31 @@ exports[`Toolshot routes/settings.tools.svelte: Views/Settings 1`] = `
     </article>
      
     <article
-      class="svelte-1b4svz0"
+      class="svelte-n00d3j"
     >
       <h4
-        class=" svelte-yxo9fq"
+        class=" svelte-177xz1h"
       >
         Broadcasting
       </h4>
        
       <label
-        class="svelte-1b4svz0"
+        class="svelte-n00d3j"
         for="broadcast-port"
       >
         Broadcasting port: 
       </label>
        
       <span
-        class="controlContainer svelte-1b4svz0"
+        class="controlContainer svelte-n00d3j"
         id="broadcast-port"
       >
         <span
-          class="settings-input svelte-1crflxh"
+          class="settings-input svelte-1rbj4tt"
         >
            
           <input
-            class="svelte-1crflxh"
+            class="svelte-1rbj4tt"
             placeholder="broadcast port placeholder"
             type="number"
           />
@@ -393,26 +393,26 @@ exports[`Toolshot routes/settings.tools.svelte: Views/Settings 1`] = `
       </span>
        
       <span
-        class="instructions svelte-1b4svz0"
+        class="instructions svelte-n00d3j"
       >
         (please restart to apply change)
       </span>
     </article>
      
     <article
-      class="svelte-1b4svz0"
+      class="svelte-n00d3j"
     >
       <h4
-        class=" svelte-yxo9fq"
+        class=" svelte-177xz1h"
       >
         About
       </h4>
        
       <div
-        class="instructions svelte-1b4svz0"
+        class="instructions svelte-n00d3j"
       >
         <p
-          class="svelte-1b4svz0"
+          class="svelte-n00d3j"
         >
           Built with love by 
           <a
@@ -424,22 +424,22 @@ exports[`Toolshot routes/settings.tools.svelte: Views/Settings 1`] = `
         </p>
          
         <p
-          class="version-container svelte-1b4svz0"
+          class="version-container svelte-n00d3j"
         >
           <div
-            class="svelte-1b4svz0"
+            class="svelte-n00d3j"
           >
             <header
-              class="svelte-1b4svz0"
+              class="svelte-n00d3j"
             >
               <div
-                class="svelte-1b4svz0"
+                class="svelte-n00d3j"
               >
                 Mélodie
               </div>
                
               <div
-                class="svelte-1b4svz0"
+                class="svelte-n00d3j"
               >
                 2.0.0
               </div>
@@ -447,25 +447,25 @@ exports[`Toolshot routes/settings.tools.svelte: Views/Settings 1`] = `
              
             <img
               alt="Mélodie"
-              class="svelte-1b4svz0"
+              class="svelte-n00d3j"
               src="icons/icon-512x512.png"
             />
              
           </div>
           <div
-            class="svelte-1b4svz0"
+            class="svelte-n00d3j"
           >
             <header
-              class="svelte-1b4svz0"
+              class="svelte-n00d3j"
             >
               <div
-                class="svelte-1b4svz0"
+                class="svelte-n00d3j"
               >
                 Electron
               </div>
                
               <div
-                class="svelte-1b4svz0"
+                class="svelte-n00d3j"
               >
                 11.0.0
               </div>
@@ -473,25 +473,25 @@ exports[`Toolshot routes/settings.tools.svelte: Views/Settings 1`] = `
              
             <img
               alt="Electron"
-              class="svelte-1b4svz0"
+              class="svelte-n00d3j"
               src="images/electron-logo.png"
             />
              
           </div>
           <div
-            class="svelte-1b4svz0"
+            class="svelte-n00d3j"
           >
             <header
-              class="svelte-1b4svz0"
+              class="svelte-n00d3j"
             >
               <div
-                class="svelte-1b4svz0"
+                class="svelte-n00d3j"
               >
                 Svelte
               </div>
                
               <div
-                class="svelte-1b4svz0"
+                class="svelte-n00d3j"
               >
                 3.43.1
               </div>
@@ -499,25 +499,25 @@ exports[`Toolshot routes/settings.tools.svelte: Views/Settings 1`] = `
              
             <img
               alt="Svelte"
-              class="svelte-1b4svz0"
+              class="svelte-n00d3j"
               src="images/svelte-logo.png"
             />
              
           </div>
           <div
-            class="svelte-1b4svz0"
+            class="svelte-n00d3j"
           >
             <header
-              class="svelte-1b4svz0"
+              class="svelte-n00d3j"
             >
               <div
-                class="svelte-1b4svz0"
+                class="svelte-n00d3j"
               >
                 Tailwind
               </div>
                
               <div
-                class="svelte-1b4svz0"
+                class="svelte-n00d3j"
               >
                 1.9.0
               </div>
@@ -525,25 +525,25 @@ exports[`Toolshot routes/settings.tools.svelte: Views/Settings 1`] = `
              
             <img
               alt="Tailwind"
-              class="svelte-1b4svz0"
+              class="svelte-n00d3j"
               src="images/tailwindcss-logo.png"
             />
              
           </div>
           <div
-            class="svelte-1b4svz0"
+            class="svelte-n00d3j"
           >
             <header
-              class="svelte-1b4svz0"
+              class="svelte-n00d3j"
             >
               <div
-                class="svelte-1b4svz0"
+                class="svelte-n00d3j"
               >
                 RxJS
               </div>
                
               <div
-                class="svelte-1b4svz0"
+                class="svelte-n00d3j"
               >
                 6.0.0
               </div>
@@ -551,25 +551,25 @@ exports[`Toolshot routes/settings.tools.svelte: Views/Settings 1`] = `
              
             <img
               alt="RxJS"
-              class="svelte-1b4svz0"
+              class="svelte-n00d3j"
               src="images/rx-logo.png"
             />
              
           </div>
           <div
-            class="svelte-1b4svz0"
+            class="svelte-n00d3j"
           >
             <header
-              class="svelte-1b4svz0"
+              class="svelte-n00d3j"
             >
               <div
-                class="svelte-1b4svz0"
+                class="svelte-n00d3j"
               >
                 SQLite
               </div>
                
               <div
-                class="svelte-1b4svz0"
+                class="svelte-n00d3j"
               >
                 3.26.0
               </div>
@@ -577,7 +577,7 @@ exports[`Toolshot routes/settings.tools.svelte: Views/Settings 1`] = `
              
             <img
               alt="SQLite"
-              class="svelte-1b4svz0"
+              class="svelte-n00d3j"
               src="images/sqlite-logo.png"
             />
              
@@ -585,7 +585,7 @@ exports[`Toolshot routes/settings.tools.svelte: Views/Settings 1`] = `
         </p>
          
         <p
-          class="svelte-1b4svz0"
+          class="svelte-n00d3j"
         >
           <span>
             Photos by:
@@ -699,7 +699,7 @@ exports[`Toolshot routes/settings.tools.svelte: Views/Settings 1`] = `
         </p>
          
         <p
-          class="svelte-1b4svz0"
+          class="svelte-n00d3j"
         >
           <span>
             Using 

--- a/common/ui/src/routes/album/__snapshots__/[id].tools.shot
+++ b/common/ui/src/routes/album/__snapshots__/[id].tools.shot
@@ -8,25 +8,25 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
     style="animation: __svelte_185617033_0 200ms linear 0ms 1 both;"
   >
     <header
-      class=" svelte-8800qh"
+      class=" svelte-t58ezf"
       style="--image: url(../images/dark-rider-JmVaNyemtN8-unsplash.jpg); --shade-color: rgba(0, 0, 0, 0.7); --bgPosition: center;"
     >
       <h1
-        class="svelte-8800qh"
+        class="svelte-t58ezf"
       >
         Cowboy Bebop - Blue
       </h1>
     </header>
      
     <section
-      class="svelte-ne8b42"
+      class="svelte-12yv3fj"
     >
       <span
-        class="image-container svelte-ne8b42"
+        class="image-container svelte-12yv3fj"
       >
         <img
           alt="cover.jpg"
-          class="h-full w-full text-3xl actionable rounded-sm svelte-dtt58s"
+          class="h-full w-full text-3xl actionable rounded-sm svelte-1psk6yi"
           height="400"
           loading="lazy"
           src="cover.jpg"
@@ -37,16 +37,16 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
       </span>
        
       <div
-        class="svelte-ne8b42"
+        class="svelte-12yv3fj"
       >
         <span
-          class="actions svelte-ne8b42"
+          class="actions svelte-12yv3fj"
         >
           <button
-            class="svelte-1vd9h50"
+            class="svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               play_arrow
             </i>
@@ -59,10 +59,10 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
           </button>
            
           <button
-            class="svelte-1vd9h50"
+            class="svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               playlist_add
             </i>
@@ -76,7 +76,7 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
         </span>
          
         <h3
-          class="svelte-ne8b42"
+          class="svelte-12yv3fj"
         >
           by 
           <a
@@ -104,72 +104,72 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
     </section>
      
     <div
-      class="disks svelte-ne8b42"
+      class="disks svelte-12yv3fj"
     >
       
        
        
        
       <table
-        class=" svelte-14yn4jg"
+        class=" svelte-1uzdiz4"
       >
         <thead
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <tr
-            class="svelte-14yn4jg"
+            class="svelte-1uzdiz4"
           >
             <th
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               #
             </th>
              
             <th
-              class="col-span-5 svelte-14yn4jg"
+              class="col-span-5 svelte-1uzdiz4"
             >
               Track
             </th>
              
             <th
-              class="col-span-4 svelte-14yn4jg"
+              class="col-span-4 svelte-1uzdiz4"
             >
               Artist
             </th>
              
              
             <th
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               Duration
             </th>
              
             <th
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             />
           </tr>
         </thead>
          
         <tbody
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <tr
-            class="svelte-14yn4jg current"
+            class="svelte-1uzdiz4 current"
           >
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               1
             </td>
              
             <td
-              class="col-span-5 svelte-14yn4jg"
+              class="col-span-5 svelte-1uzdiz4"
             >
               American Money
             </td>
              
             <td
-              class="col-span-4 svelte-14yn4jg"
+              class="col-span-4 svelte-1uzdiz4"
             >
               <a
                 class="underlined"
@@ -190,24 +190,24 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               5:32
             </td>
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -223,22 +223,22 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
           </tr>
           <tr
-            class="svelte-14yn4jg"
+            class="svelte-1uzdiz4"
           >
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               2
             </td>
              
             <td
-              class="col-span-5 svelte-14yn4jg"
+              class="col-span-5 svelte-1uzdiz4"
             >
               Fantaisie Sign
             </td>
              
             <td
-              class="col-span-4 svelte-14yn4jg"
+              class="col-span-4 svelte-1uzdiz4"
             >
               <a
                 class="underlined"
@@ -259,24 +259,24 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               3:35
             </td>
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -296,7 +296,7 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
       
       
       <h3
-        class="svelte-11p7ayw"
+        class="svelte-w4sfb"
       >
         Disk #1
       </h3>
@@ -304,65 +304,65 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
        
        
       <table
-        class=" svelte-14yn4jg"
+        class=" svelte-1uzdiz4"
       >
         <thead
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <tr
-            class="svelte-14yn4jg"
+            class="svelte-1uzdiz4"
           >
             <th
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               #
             </th>
              
             <th
-              class="col-span-5 svelte-14yn4jg"
+              class="col-span-5 svelte-1uzdiz4"
             >
               Track
             </th>
              
             <th
-              class="col-span-4 svelte-14yn4jg"
+              class="col-span-4 svelte-1uzdiz4"
             >
               Artist
             </th>
              
              
             <th
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               Duration
             </th>
              
             <th
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             />
           </tr>
         </thead>
          
         <tbody
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <tr
-            class="svelte-14yn4jg"
+            class="svelte-1uzdiz4"
           >
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               2
             </td>
              
             <td
-              class="col-span-5 svelte-14yn4jg"
+              class="col-span-5 svelte-1uzdiz4"
             >
               Vitamin A
             </td>
              
             <td
-              class="col-span-4 svelte-14yn4jg"
+              class="col-span-4 svelte-1uzdiz4"
             >
               <a
                 class="underlined"
@@ -383,24 +383,24 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               4:41
             </td>
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -416,22 +416,22 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
           </tr>
           <tr
-            class="svelte-14yn4jg"
+            class="svelte-1uzdiz4"
           >
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               3
             </td>
              
             <td
-              class="col-span-5 svelte-14yn4jg"
+              class="col-span-5 svelte-1uzdiz4"
             >
               Don't Bother None
             </td>
              
             <td
-              class="col-span-4 svelte-14yn4jg"
+              class="col-span-4 svelte-1uzdiz4"
             >
               <a
                 class="underlined"
@@ -452,24 +452,24 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               3:45
             </td>
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -485,22 +485,22 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
           </tr>
           <tr
-            class="svelte-14yn4jg"
+            class="svelte-1uzdiz4"
           >
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               4
             </td>
              
             <td
-              class="col-span-5 svelte-14yn4jg"
+              class="col-span-5 svelte-1uzdiz4"
             >
               Want it All Back
             </td>
              
             <td
-              class="col-span-4 svelte-14yn4jg"
+              class="col-span-4 svelte-1uzdiz4"
             >
               <a
                 class="underlined"
@@ -521,24 +521,24 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               3:51
             </td>
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -554,22 +554,22 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
           </tr>
           <tr
-            class="svelte-14yn4jg"
+            class="svelte-1uzdiz4"
           >
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               5
             </td>
              
             <td
-              class="col-span-5 svelte-14yn4jg"
+              class="col-span-5 svelte-1uzdiz4"
             >
               Bindy
             </td>
              
             <td
-              class="col-span-4 svelte-14yn4jg"
+              class="col-span-4 svelte-1uzdiz4"
             >
               <a
                 class="underlined"
@@ -590,24 +590,24 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               0:15
             </td>
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -623,22 +623,22 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
           </tr>
           <tr
-            class="svelte-14yn4jg"
+            class="svelte-1uzdiz4"
           >
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               6
             </td>
              
             <td
-              class="col-span-5 svelte-14yn4jg"
+              class="col-span-5 svelte-1uzdiz4"
             >
               You Make Me Coo
             </td>
              
             <td
-              class="col-span-4 svelte-14yn4jg"
+              class="col-span-4 svelte-1uzdiz4"
             >
               <a
                 class="underlined"
@@ -659,24 +659,24 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               3:14
             </td>
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -692,22 +692,22 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
           </tr>
           <tr
-            class="svelte-14yn4jg"
+            class="svelte-1uzdiz4"
           >
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               7
             </td>
              
             <td
-              class="col-span-5 svelte-14yn4jg"
+              class="col-span-5 svelte-1uzdiz4"
             >
               Vitamin C
             </td>
              
             <td
-              class="col-span-4 svelte-14yn4jg"
+              class="col-span-4 svelte-1uzdiz4"
             >
               <a
                 class="underlined"
@@ -728,24 +728,24 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               5:24
             </td>
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -761,22 +761,22 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
           </tr>
           <tr
-            class="svelte-14yn4jg"
+            class="svelte-1uzdiz4"
           >
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               8
             </td>
              
             <td
-              class="col-span-5 svelte-14yn4jg"
+              class="col-span-5 svelte-1uzdiz4"
             >
               Gateway
             </td>
              
             <td
-              class="col-span-4 svelte-14yn4jg"
+              class="col-span-4 svelte-1uzdiz4"
             >
               <a
                 class="underlined"
@@ -797,24 +797,24 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               0:16
             </td>
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -830,22 +830,22 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
           </tr>
           <tr
-            class="svelte-14yn4jg"
+            class="svelte-1uzdiz4"
           >
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               9
             </td>
              
             <td
-              class="col-span-5 svelte-14yn4jg"
+              class="col-span-5 svelte-1uzdiz4"
             >
               Forever Broke
             </td>
              
             <td
-              class="col-span-4 svelte-14yn4jg"
+              class="col-span-4 svelte-1uzdiz4"
             >
               <a
                 class="underlined"
@@ -866,24 +866,24 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               1:36
             </td>
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -903,7 +903,7 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
       
       
       <h3
-        class="svelte-11p7ayw"
+        class="svelte-w4sfb"
       >
         Disk #2
       </h3>
@@ -911,65 +911,65 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
        
        
       <table
-        class=" svelte-14yn4jg"
+        class=" svelte-1uzdiz4"
       >
         <thead
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <tr
-            class="svelte-14yn4jg"
+            class="svelte-1uzdiz4"
           >
             <th
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               #
             </th>
              
             <th
-              class="col-span-5 svelte-14yn4jg"
+              class="col-span-5 svelte-1uzdiz4"
             >
               Track
             </th>
              
             <th
-              class="col-span-4 svelte-14yn4jg"
+              class="col-span-4 svelte-1uzdiz4"
             >
               Artist
             </th>
              
              
             <th
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               Duration
             </th>
              
             <th
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             />
           </tr>
         </thead>
          
         <tbody
-          class="svelte-14yn4jg"
+          class="svelte-1uzdiz4"
         >
           <tr
-            class="svelte-14yn4jg"
+            class="svelte-1uzdiz4"
           >
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               2
             </td>
              
             <td
-              class="col-span-5 svelte-14yn4jg"
+              class="col-span-5 svelte-1uzdiz4"
             >
               Cats on Mars
             </td>
              
             <td
-              class="col-span-4 svelte-14yn4jg"
+              class="col-span-4 svelte-1uzdiz4"
             >
               <a
                 class="underlined"
@@ -990,24 +990,24 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               0:07
             </td>
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -1023,22 +1023,22 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
           </tr>
           <tr
-            class="svelte-14yn4jg"
+            class="svelte-1uzdiz4"
           >
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               3
             </td>
              
             <td
-              class="col-span-5 svelte-14yn4jg"
+              class="col-span-5 svelte-1uzdiz4"
             >
               LIVE in Baghdad
             </td>
              
             <td
-              class="col-span-4 svelte-14yn4jg"
+              class="col-span-4 svelte-1uzdiz4"
             >
               <a
                 class="underlined"
@@ -1059,24 +1059,24 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               2:59
             </td>
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -1092,22 +1092,22 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
           </tr>
           <tr
-            class="svelte-14yn4jg"
+            class="svelte-1uzdiz4"
           >
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               4
             </td>
              
             <td
-              class="col-span-5 svelte-14yn4jg"
+              class="col-span-5 svelte-1uzdiz4"
             >
               Vitamin B
             </td>
              
             <td
-              class="col-span-4 svelte-14yn4jg"
+              class="col-span-4 svelte-1uzdiz4"
             >
               <a
                 class="underlined"
@@ -1128,24 +1128,24 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               4:06
             </td>
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -1161,22 +1161,22 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
           </tr>
           <tr
-            class="svelte-14yn4jg"
+            class="svelte-1uzdiz4"
           >
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               5
             </td>
              
             <td
-              class="col-span-5 svelte-14yn4jg"
+              class="col-span-5 svelte-1uzdiz4"
             >
               Green Bird
             </td>
              
             <td
-              class="col-span-4 svelte-14yn4jg"
+              class="col-span-4 svelte-1uzdiz4"
             >
               <a
                 class="underlined"
@@ -1197,24 +1197,24 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               2:33
             </td>
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -1230,22 +1230,22 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
           </tr>
           <tr
-            class="svelte-14yn4jg"
+            class="svelte-1uzdiz4"
           >
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               6
             </td>
              
             <td
-              class="col-span-5 svelte-14yn4jg"
+              class="col-span-5 svelte-1uzdiz4"
             >
               ELM
             </td>
              
             <td
-              class="col-span-4 svelte-14yn4jg"
+              class="col-span-4 svelte-1uzdiz4"
             >
               <a
                 class="underlined"
@@ -1266,24 +1266,24 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               6:55
             </td>
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -1299,22 +1299,22 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
           </tr>
           <tr
-            class="svelte-14yn4jg"
+            class="svelte-1uzdiz4"
           >
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               7
             </td>
              
             <td
-              class="col-span-5 svelte-14yn4jg"
+              class="col-span-5 svelte-1uzdiz4"
             >
               The Singing Sea
             </td>
              
             <td
-              class="col-span-4 svelte-14yn4jg"
+              class="col-span-4 svelte-1uzdiz4"
             >
               <a
                 class="underlined"
@@ -1335,24 +1335,24 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               6:41
             </td>
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -1368,22 +1368,22 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
           </tr>
           <tr
-            class="svelte-14yn4jg"
+            class="svelte-1uzdiz4"
           >
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               8
             </td>
              
             <td
-              class="col-span-5 svelte-14yn4jg"
+              class="col-span-5 svelte-1uzdiz4"
             >
               The Egg and You!
             </td>
              
             <td
-              class="col-span-4 svelte-14yn4jg"
+              class="col-span-4 svelte-1uzdiz4"
             >
               <a
                 class="underlined"
@@ -1404,24 +1404,24 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               4:47
             </td>
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -1437,22 +1437,22 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
           </tr>
           <tr
-            class="svelte-14yn4jg"
+            class="svelte-1uzdiz4"
           >
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               9
             </td>
              
             <td
-              class="col-span-5 svelte-14yn4jg"
+              class="col-span-5 svelte-1uzdiz4"
             >
               Power of Kungfu Remix
             </td>
              
             <td
-              class="col-span-4 svelte-14yn4jg"
+              class="col-span-4 svelte-1uzdiz4"
             >
               <a
                 class="underlined"
@@ -1473,24 +1473,24 @@ exports[`Toolshot routes/album/[id].tools.svelte: Views/Album Details 1`] = `
              
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               2:22
             </td>
              
             <td
-              class="svelte-14yn4jg"
+              class="svelte-1uzdiz4"
             >
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>

--- a/common/ui/src/routes/artist/__snapshots__/[id].tools.shot
+++ b/common/ui/src/routes/artist/__snapshots__/[id].tools.shot
@@ -8,25 +8,25 @@ exports[`Toolshot routes/artist/[id].tools.svelte: Views/Artist Details 1`] = `
     style="animation: __svelte_185617033_0 200ms linear 0ms 1 both;"
   >
     <header
-      class=" svelte-8800qh"
+      class=" svelte-t58ezf"
       style="--image: url(../images/harry-swales-Vfvf3H-5OHc-unsplash.jpg); --shade-color: rgba(0, 0, 0, 0.7); --bgPosition: center 40%;"
     >
       <h1
-        class="svelte-8800qh"
+        class="svelte-t58ezf"
       >
         Foo Fighters
       </h1>
     </header>
      
     <section
-      class="svelte-1h6bhsr"
+      class="svelte-154wk3x"
     >
       <span
-        class="image-container svelte-1h6bhsr"
+        class="image-container svelte-154wk3x"
       >
         <img
           alt="./avatar.jpg"
-          class="h-full w-full text-3xl actionable rounded-full svelte-dtt58s"
+          class="h-full w-full text-3xl actionable rounded-full svelte-1psk6yi"
           height="400"
           loading="lazy"
           src="./avatar.jpg"
@@ -37,16 +37,16 @@ exports[`Toolshot routes/artist/[id].tools.svelte: Views/Artist Details 1`] = `
       </span>
        
       <div
-        class="svelte-1h6bhsr"
+        class="svelte-154wk3x"
       >
         <span
-          class="actions svelte-1h6bhsr"
+          class="actions svelte-154wk3x"
         >
           <button
-            class="svelte-1vd9h50"
+            class="svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               play_arrow
             </i>
@@ -59,10 +59,10 @@ exports[`Toolshot routes/artist/[id].tools.svelte: Views/Artist Details 1`] = `
           </button>
            
           <button
-            class="svelte-1vd9h50"
+            class="svelte-1e4q28k"
           >
             <i
-              class="material-icons svelte-1vd9h50"
+              class="material-icons svelte-1e4q28k"
             >
               playlist_add
             </i>
@@ -76,7 +76,7 @@ exports[`Toolshot routes/artist/[id].tools.svelte: Views/Artist Details 1`] = `
         </span>
          
         <span
-          class="bio svelte-1h6bhsr"
+          class="bio svelte-154wk3x"
         >
           Foo Fighters is an American alternative rock band formed in Seattle in 1994. It was founded by Nirvana drummer Dave Grohl as a one-man project following the death of Kurt Cobain and the resulting dissolution of his previous band. The group got its name from the UFOs and various aerial phenomena that were reported by Allied aircraft pilots in World War II, which were known collectively as foo fighters. Prior to the release of the Foo Fighters' 1995 debut album Foo Fighters, which featured Grohl as the only official member, Grohl recruited bassist Nate Mendel and drummer William Goldsmith, both formerly of Sunny Day Real Estate, as well as fellow Nirvana touring bandmate Pat Smear as guitarist to complete the lineup. 
 The band began with performances in Portland, Oregon. Goldsmith quit during the recording of the group's second album, The Colour and the Shape (1997) when most of the drum parts were re-recorded by Grohl himself. Smear's departure followed soon afterward. They were replaced by Taylor Hawkins and Franz Stahl, respectively, although Stahl was fired before the recording of the group's third album, There Is Nothing Left to Lose (1999).
@@ -86,26 +86,26 @@ The band briefly continued as a trio until Chris Shiflett joined as the band's l
     </section>
      
     <div
-      class="albums svelte-1h6bhsr"
+      class="albums svelte-154wk3x"
     >
       <a
-        class="p-4 svelte-1h6bhsr"
+        class="p-4 svelte-154wk3x"
         href="#/album/2358057182"
       >
          
         <span
-          class="svelte-9e8ghi"
+          class="svelte-4r86n"
           role="article"
         >
           <div
-            class="content svelte-9e8ghi"
+            class="content svelte-4r86n"
           >
             <span
-              class="artwork svelte-9e8ghi"
+              class="artwork svelte-4r86n"
             >
               <img
                 alt="cover.jpg"
-                class="h-full w-full rounded-sm svelte-dtt58s"
+                class="h-full w-full rounded-sm svelte-1psk6yi"
                 height="256"
                 loading="lazy"
                 src="cover.jpg"
@@ -116,15 +116,15 @@ The band briefly continued as a trio until Chris Shiflett joined as the band's l
             </span>
              
             <p
-              class="controls svelte-9e8ghi"
+              class="controls svelte-4r86n"
             >
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="play"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   play_arrow
                 </i>
@@ -134,11 +134,11 @@ The band briefly continued as a trio until Chris Shiflett joined as the band's l
               </button>
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="enqueue"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   playlist_add
                 </i>
@@ -150,16 +150,16 @@ The band briefly continued as a trio until Chris Shiflett joined as the band's l
           </div>
            
           <header
-            class="svelte-9e8ghi"
+            class="svelte-4r86n"
           >
             <h3
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
             >
               Foo Fighters
             </h3>
              
             <h4
-              class="svelte-1vmk98n"
+              class="svelte-rw2hde"
               slot="details"
             >
                
@@ -170,23 +170,23 @@ The band briefly continued as a trio until Chris Shiflett joined as the band's l
          
       </a>
       <a
-        class="p-4 svelte-1h6bhsr"
+        class="p-4 svelte-154wk3x"
         href="#/album/2084548277"
       >
          
         <span
-          class="svelte-9e8ghi"
+          class="svelte-4r86n"
           role="article"
         >
           <div
-            class="content svelte-9e8ghi"
+            class="content svelte-4r86n"
           >
             <span
-              class="artwork svelte-9e8ghi"
+              class="artwork svelte-4r86n"
             >
               <img
                 alt="(1997) The Colour and the Shape/cover.jpg"
-                class="h-full w-full rounded-sm svelte-dtt58s"
+                class="h-full w-full rounded-sm svelte-1psk6yi"
                 height="256"
                 loading="lazy"
                 src="(1997) The Colour and the Shape/cover.jpg"
@@ -197,15 +197,15 @@ The band briefly continued as a trio until Chris Shiflett joined as the band's l
             </span>
              
             <p
-              class="controls svelte-9e8ghi"
+              class="controls svelte-4r86n"
             >
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="play"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   play_arrow
                 </i>
@@ -215,11 +215,11 @@ The band briefly continued as a trio until Chris Shiflett joined as the band's l
               </button>
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="enqueue"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   playlist_add
                 </i>
@@ -231,16 +231,16 @@ The band briefly continued as a trio until Chris Shiflett joined as the band's l
           </div>
            
           <header
-            class="svelte-9e8ghi"
+            class="svelte-4r86n"
           >
             <h3
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
             >
               The Colour And The Shape
             </h3>
              
             <h4
-              class="svelte-1vmk98n"
+              class="svelte-rw2hde"
               slot="details"
             >
                
@@ -251,23 +251,23 @@ The band briefly continued as a trio until Chris Shiflett joined as the band's l
          
       </a>
       <a
-        class="p-4 svelte-1h6bhsr"
+        class="p-4 svelte-154wk3x"
         href="#/album/1783531088"
       >
          
         <span
-          class="svelte-9e8ghi"
+          class="svelte-4r86n"
           role="article"
         >
           <div
-            class="content svelte-9e8ghi"
+            class="content svelte-4r86n"
           >
             <span
-              class="artwork svelte-9e8ghi"
+              class="artwork svelte-4r86n"
             >
               <img
                 alt="(1999) There Is Nothing Left To Lose/cover.jpg"
-                class="h-full w-full rounded-sm svelte-dtt58s"
+                class="h-full w-full rounded-sm svelte-1psk6yi"
                 height="256"
                 loading="lazy"
                 src="(1999) There Is Nothing Left To Lose/cover.jpg"
@@ -278,15 +278,15 @@ The band briefly continued as a trio until Chris Shiflett joined as the band's l
             </span>
              
             <p
-              class="controls svelte-9e8ghi"
+              class="controls svelte-4r86n"
             >
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="play"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   play_arrow
                 </i>
@@ -296,11 +296,11 @@ The band briefly continued as a trio until Chris Shiflett joined as the band's l
               </button>
                
               <button
-                class="primary iconOnly large svelte-1vd9h50"
+                class="primary iconOnly large svelte-1e4q28k"
                 data-testid="enqueue"
               >
                 <i
-                  class="material-icons svelte-1vd9h50"
+                  class="material-icons svelte-1e4q28k"
                 >
                   playlist_add
                 </i>
@@ -312,16 +312,16 @@ The band briefly continued as a trio until Chris Shiflett joined as the band's l
           </div>
            
           <header
-            class="svelte-9e8ghi"
+            class="svelte-4r86n"
           >
             <h3
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
             >
               There Is Nothing Left To Lose
             </h3>
              
             <h4
-              class="svelte-1vmk98n"
+              class="svelte-rw2hde"
               slot="details"
             >
                

--- a/common/ui/src/routes/playlist/__snapshots__/[id].tools.shot
+++ b/common/ui/src/routes/playlist/__snapshots__/[id].tools.shot
@@ -8,24 +8,24 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
     style="animation: __svelte_185617033_0 200ms linear 0ms 1 both;"
   >
     <header
-      class=" svelte-8800qh"
+      class=" svelte-t58ezf"
       style="--image: url(../images/bantersnaps-nE1K_qO2z38-unsplash.jpg); --shade-color: rgba(0, 0, 0, 0.7); --bgPosition: center 60%;"
     >
       <h1
-        class="svelte-8800qh"
+        class="svelte-t58ezf"
       >
         Awesome mix, vol. 1
       </h1>
     </header>
      
     <section
-      class="svelte-18hmlf4"
+      class="svelte-1v0u6y"
     >
       <button
-        class="svelte-1vd9h50"
+        class="svelte-1e4q28k"
       >
         <i
-          class="material-icons svelte-1vd9h50"
+          class="material-icons svelte-1e4q28k"
         >
           play_arrow
         </i>
@@ -38,10 +38,10 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
       </button>
        
       <button
-        class="svelte-1vd9h50"
+        class="svelte-1e4q28k"
       >
         <i
-          class="material-icons svelte-1vd9h50"
+          class="material-icons svelte-1e4q28k"
         >
           playlist_add
         </i>
@@ -54,10 +54,10 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
       </button>
        
       <button
-        class="svelte-1vd9h50"
+        class="svelte-1e4q28k"
       >
         <i
-          class="material-icons svelte-1vd9h50"
+          class="material-icons svelte-1e4q28k"
         >
           edit
         </i>
@@ -70,10 +70,10 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
       </button>
        
       <button
-        class="svelte-1vd9h50"
+        class="svelte-1e4q28k"
       >
         <i
-          class="material-icons svelte-1vd9h50"
+          class="material-icons svelte-1e4q28k"
         >
           save_alt
         </i>
@@ -86,10 +86,10 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
       </button>
        
       <button
-        class="svelte-1vd9h50"
+        class="svelte-1e4q28k"
       >
         <i
-          class="material-icons svelte-1vd9h50"
+          class="material-icons svelte-1e4q28k"
         >
           delete
         </i>
@@ -102,11 +102,11 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
       </button>
        
       <div
-        class="divider svelte-18hmlf4"
+        class="divider svelte-1v0u6y"
       />
        
       <div
-        class="meta svelte-18hmlf4"
+        class="meta svelte-1v0u6y"
       >
         18 tracks
          
@@ -117,89 +117,89 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
     </section>
      
     <div
-      class="tracks svelte-18hmlf4"
+      class="tracks svelte-1v0u6y"
     >
        
        
       <table
-        class="svelte-1qu5p5x"
+        class="svelte-1s1441n"
       >
         <thead
-          class="svelte-1qu5p5x"
+          class="svelte-1s1441n"
         >
           <tr
-            class="svelte-1qu5p5x"
+            class="svelte-1s1441n"
           >
             <th
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             >
               #
             </th>
              
             <th
-              class="col-span-5 svelte-1qu5p5x"
+              class="col-span-5 svelte-1s1441n"
             >
               Track
             </th>
              
             <th
-              class="col-span-1 svelte-1qu5p5x"
+              class="col-span-1 svelte-1s1441n"
             >
               Duration
             </th>
              
             <th
-              class="col-span-4 svelte-1qu5p5x"
+              class="col-span-4 svelte-1s1441n"
             >
               Album
             </th>
              
             <th
-              class="svelte-1qu5p5x"
+              class="svelte-1s1441n"
             />
           </tr>
         </thead>
          
         <tbody
-          class="svelte-1qu5p5x"
+          class="svelte-1s1441n"
         >
           <ol>
             <li
-              class="svelte-qra3ls"
+              class="svelte-w3rzzq"
               draggable="true"
             >
               <tr
-                class="svelte-1qu5p5x"
+                class="svelte-1s1441n"
                 slot="item"
               >
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   1
                 </td>
                  
                 <td
-                  class="col-span-6 svelte-1qu5p5x"
+                  class="col-span-6 svelte-1s1441n"
                 >
                   <div
-                    class="undefined root svelte-1wnrcpi"
+                    class="undefined root svelte-30dtyc"
                   >
                     <a
                       class="flex-none"
                       href="#/album/1"
                     >
                       <img
-                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                         height="256"
                         loading="lazy"
                         width="256"
                       />
                        
                       <span
-                        class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                        class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                       >
                         <i
-                          class="material-icons svelte-dtt58s"
+                          class="material-icons svelte-1psk6yi"
                         >
                           music_note
                         </i>
@@ -208,10 +208,10 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </a>
                      
                     <div
-                      class="track svelte-1wnrcpi"
+                      class="track svelte-30dtyc"
                     >
                       <span
-                        class="title svelte-1wnrcpi"
+                        class="title svelte-30dtyc"
                       >
                         American Money
                       </span>
@@ -236,7 +236,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </div>
                      
                     <div
-                      class="duration svelte-1wnrcpi"
+                      class="duration svelte-30dtyc"
                     >
                       5:32
                     </div>
@@ -245,7 +245,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="col-span-4 svelte-1qu5p5x"
+                  class="col-span-4 svelte-1s1441n"
                 >
                   <a
                     class="underlined"
@@ -257,18 +257,18 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   <span
                     aria-expanded="false"
                     aria-haspopup="menu"
-                    class="wrapper svelte-1x6dshm"
+                    class="wrapper svelte-11prmkk"
                   >
                     <button
-                      class="iconOnly noBorder svelte-1vd9h50"
+                      class="iconOnly noBorder svelte-1e4q28k"
                     >
                       <i
-                        class="material-icons svelte-1vd9h50"
+                        class="material-icons svelte-1e4q28k"
                       >
                         more_vert
                       </i>
@@ -285,41 +285,41 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                
             </li>
             <li
-              class="svelte-qra3ls"
+              class="svelte-w3rzzq"
               draggable="true"
             >
               <tr
-                class="svelte-1qu5p5x"
+                class="svelte-1s1441n"
                 slot="item"
               >
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   2
                 </td>
                  
                 <td
-                  class="col-span-6 svelte-1qu5p5x"
+                  class="col-span-6 svelte-1s1441n"
                 >
                   <div
-                    class="undefined root svelte-1wnrcpi"
+                    class="undefined root svelte-30dtyc"
                   >
                     <a
                       class="flex-none"
                       href="#/album/1"
                     >
                       <img
-                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                         height="256"
                         loading="lazy"
                         width="256"
                       />
                        
                       <span
-                        class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                        class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                       >
                         <i
-                          class="material-icons svelte-dtt58s"
+                          class="material-icons svelte-1psk6yi"
                         >
                           music_note
                         </i>
@@ -328,10 +328,10 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </a>
                      
                     <div
-                      class="track svelte-1wnrcpi"
+                      class="track svelte-30dtyc"
                     >
                       <span
-                        class="title svelte-1wnrcpi"
+                        class="title svelte-30dtyc"
                       >
                         Fantaisie Sign
                       </span>
@@ -356,7 +356,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </div>
                      
                     <div
-                      class="duration svelte-1wnrcpi"
+                      class="duration svelte-30dtyc"
                     >
                       3:35
                     </div>
@@ -365,7 +365,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="col-span-4 svelte-1qu5p5x"
+                  class="col-span-4 svelte-1s1441n"
                 >
                   <a
                     class="underlined"
@@ -377,18 +377,18 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   <span
                     aria-expanded="false"
                     aria-haspopup="menu"
-                    class="wrapper svelte-1x6dshm"
+                    class="wrapper svelte-11prmkk"
                   >
                     <button
-                      class="iconOnly noBorder svelte-1vd9h50"
+                      class="iconOnly noBorder svelte-1e4q28k"
                     >
                       <i
-                        class="material-icons svelte-1vd9h50"
+                        class="material-icons svelte-1e4q28k"
                       >
                         more_vert
                       </i>
@@ -405,41 +405,41 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                
             </li>
             <li
-              class="svelte-qra3ls"
+              class="svelte-w3rzzq"
               draggable="true"
             >
               <tr
-                class="svelte-1qu5p5x"
+                class="svelte-1s1441n"
                 slot="item"
               >
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   3
                 </td>
                  
                 <td
-                  class="col-span-6 svelte-1qu5p5x"
+                  class="col-span-6 svelte-1s1441n"
                 >
                   <div
-                    class="undefined root svelte-1wnrcpi"
+                    class="undefined root svelte-30dtyc"
                   >
                     <a
                       class="flex-none"
                       href="#/album/1"
                     >
                       <img
-                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                         height="256"
                         loading="lazy"
                         width="256"
                       />
                        
                       <span
-                        class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                        class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                       >
                         <i
-                          class="material-icons svelte-dtt58s"
+                          class="material-icons svelte-1psk6yi"
                         >
                           music_note
                         </i>
@@ -448,10 +448,10 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </a>
                      
                     <div
-                      class="track svelte-1wnrcpi"
+                      class="track svelte-30dtyc"
                     >
                       <span
-                        class="title svelte-1wnrcpi"
+                        class="title svelte-30dtyc"
                       >
                         Don't Bother None
                       </span>
@@ -476,7 +476,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </div>
                      
                     <div
-                      class="duration svelte-1wnrcpi"
+                      class="duration svelte-30dtyc"
                     >
                       3:45
                     </div>
@@ -485,7 +485,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="col-span-4 svelte-1qu5p5x"
+                  class="col-span-4 svelte-1s1441n"
                 >
                   <a
                     class="underlined"
@@ -497,18 +497,18 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   <span
                     aria-expanded="false"
                     aria-haspopup="menu"
-                    class="wrapper svelte-1x6dshm"
+                    class="wrapper svelte-11prmkk"
                   >
                     <button
-                      class="iconOnly noBorder svelte-1vd9h50"
+                      class="iconOnly noBorder svelte-1e4q28k"
                     >
                       <i
-                        class="material-icons svelte-1vd9h50"
+                        class="material-icons svelte-1e4q28k"
                       >
                         more_vert
                       </i>
@@ -525,41 +525,41 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                
             </li>
             <li
-              class="svelte-qra3ls"
+              class="svelte-w3rzzq"
               draggable="true"
             >
               <tr
-                class="svelte-1qu5p5x"
+                class="svelte-1s1441n"
                 slot="item"
               >
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   4
                 </td>
                  
                 <td
-                  class="col-span-6 svelte-1qu5p5x"
+                  class="col-span-6 svelte-1s1441n"
                 >
                   <div
-                    class="undefined root svelte-1wnrcpi"
+                    class="undefined root svelte-30dtyc"
                   >
                     <a
                       class="flex-none"
                       href="#/album/1"
                     >
                       <img
-                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                         height="256"
                         loading="lazy"
                         width="256"
                       />
                        
                       <span
-                        class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                        class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                       >
                         <i
-                          class="material-icons svelte-dtt58s"
+                          class="material-icons svelte-1psk6yi"
                         >
                           music_note
                         </i>
@@ -568,10 +568,10 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </a>
                      
                     <div
-                      class="track svelte-1wnrcpi"
+                      class="track svelte-30dtyc"
                     >
                       <span
-                        class="title svelte-1wnrcpi"
+                        class="title svelte-30dtyc"
                       >
                         Vitamin A
                       </span>
@@ -596,7 +596,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </div>
                      
                     <div
-                      class="duration svelte-1wnrcpi"
+                      class="duration svelte-30dtyc"
                     >
                       4:41
                     </div>
@@ -605,7 +605,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="col-span-4 svelte-1qu5p5x"
+                  class="col-span-4 svelte-1s1441n"
                 >
                   <a
                     class="underlined"
@@ -617,18 +617,18 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   <span
                     aria-expanded="false"
                     aria-haspopup="menu"
-                    class="wrapper svelte-1x6dshm"
+                    class="wrapper svelte-11prmkk"
                   >
                     <button
-                      class="iconOnly noBorder svelte-1vd9h50"
+                      class="iconOnly noBorder svelte-1e4q28k"
                     >
                       <i
-                        class="material-icons svelte-1vd9h50"
+                        class="material-icons svelte-1e4q28k"
                       >
                         more_vert
                       </i>
@@ -645,41 +645,41 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                
             </li>
             <li
-              class="svelte-qra3ls"
+              class="svelte-w3rzzq"
               draggable="true"
             >
               <tr
-                class="svelte-1qu5p5x"
+                class="svelte-1s1441n"
                 slot="item"
               >
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   5
                 </td>
                  
                 <td
-                  class="col-span-6 svelte-1qu5p5x"
+                  class="col-span-6 svelte-1s1441n"
                 >
                   <div
-                    class="undefined root svelte-1wnrcpi"
+                    class="undefined root svelte-30dtyc"
                   >
                     <a
                       class="flex-none"
                       href="#/album/1"
                     >
                       <img
-                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                         height="256"
                         loading="lazy"
                         width="256"
                       />
                        
                       <span
-                        class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                        class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                       >
                         <i
-                          class="material-icons svelte-dtt58s"
+                          class="material-icons svelte-1psk6yi"
                         >
                           music_note
                         </i>
@@ -688,10 +688,10 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </a>
                      
                     <div
-                      class="track svelte-1wnrcpi"
+                      class="track svelte-30dtyc"
                     >
                       <span
-                        class="title svelte-1wnrcpi"
+                        class="title svelte-30dtyc"
                       >
                         LIVE in Baghdad
                       </span>
@@ -716,7 +716,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </div>
                      
                     <div
-                      class="duration svelte-1wnrcpi"
+                      class="duration svelte-30dtyc"
                     >
                       2:59
                     </div>
@@ -725,7 +725,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="col-span-4 svelte-1qu5p5x"
+                  class="col-span-4 svelte-1s1441n"
                 >
                   <a
                     class="underlined"
@@ -737,18 +737,18 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   <span
                     aria-expanded="false"
                     aria-haspopup="menu"
-                    class="wrapper svelte-1x6dshm"
+                    class="wrapper svelte-11prmkk"
                   >
                     <button
-                      class="iconOnly noBorder svelte-1vd9h50"
+                      class="iconOnly noBorder svelte-1e4q28k"
                     >
                       <i
-                        class="material-icons svelte-1vd9h50"
+                        class="material-icons svelte-1e4q28k"
                       >
                         more_vert
                       </i>
@@ -765,41 +765,41 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                
             </li>
             <li
-              class="svelte-qra3ls"
+              class="svelte-w3rzzq"
               draggable="true"
             >
               <tr
-                class="svelte-1qu5p5x"
+                class="svelte-1s1441n"
                 slot="item"
               >
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   6
                 </td>
                  
                 <td
-                  class="col-span-6 svelte-1qu5p5x"
+                  class="col-span-6 svelte-1s1441n"
                 >
                   <div
-                    class="undefined root svelte-1wnrcpi"
+                    class="undefined root svelte-30dtyc"
                   >
                     <a
                       class="flex-none"
                       href="#/album/1"
                     >
                       <img
-                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                         height="256"
                         loading="lazy"
                         width="256"
                       />
                        
                       <span
-                        class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                        class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                       >
                         <i
-                          class="material-icons svelte-dtt58s"
+                          class="material-icons svelte-1psk6yi"
                         >
                           music_note
                         </i>
@@ -808,10 +808,10 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </a>
                      
                     <div
-                      class="track svelte-1wnrcpi"
+                      class="track svelte-30dtyc"
                     >
                       <span
-                        class="title svelte-1wnrcpi"
+                        class="title svelte-30dtyc"
                       >
                         Cats on Mars
                       </span>
@@ -836,7 +836,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </div>
                      
                     <div
-                      class="duration svelte-1wnrcpi"
+                      class="duration svelte-30dtyc"
                     >
                       0:07
                     </div>
@@ -845,7 +845,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="col-span-4 svelte-1qu5p5x"
+                  class="col-span-4 svelte-1s1441n"
                 >
                   <a
                     class="underlined"
@@ -857,18 +857,18 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   <span
                     aria-expanded="false"
                     aria-haspopup="menu"
-                    class="wrapper svelte-1x6dshm"
+                    class="wrapper svelte-11prmkk"
                   >
                     <button
-                      class="iconOnly noBorder svelte-1vd9h50"
+                      class="iconOnly noBorder svelte-1e4q28k"
                     >
                       <i
-                        class="material-icons svelte-1vd9h50"
+                        class="material-icons svelte-1e4q28k"
                       >
                         more_vert
                       </i>
@@ -885,41 +885,41 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                
             </li>
             <li
-              class="svelte-qra3ls"
+              class="svelte-w3rzzq"
               draggable="true"
             >
               <tr
-                class="svelte-1qu5p5x"
+                class="svelte-1s1441n"
                 slot="item"
               >
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   7
                 </td>
                  
                 <td
-                  class="col-span-6 svelte-1qu5p5x"
+                  class="col-span-6 svelte-1s1441n"
                 >
                   <div
-                    class="undefined root svelte-1wnrcpi"
+                    class="undefined root svelte-30dtyc"
                   >
                     <a
                       class="flex-none"
                       href="#/album/1"
                     >
                       <img
-                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                         height="256"
                         loading="lazy"
                         width="256"
                       />
                        
                       <span
-                        class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                        class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                       >
                         <i
-                          class="material-icons svelte-dtt58s"
+                          class="material-icons svelte-1psk6yi"
                         >
                           music_note
                         </i>
@@ -928,10 +928,10 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </a>
                      
                     <div
-                      class="track svelte-1wnrcpi"
+                      class="track svelte-30dtyc"
                     >
                       <span
-                        class="title svelte-1wnrcpi"
+                        class="title svelte-30dtyc"
                       >
                         Want it All Back
                       </span>
@@ -956,7 +956,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </div>
                      
                     <div
-                      class="duration svelte-1wnrcpi"
+                      class="duration svelte-30dtyc"
                     >
                       3:51
                     </div>
@@ -965,7 +965,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="col-span-4 svelte-1qu5p5x"
+                  class="col-span-4 svelte-1s1441n"
                 >
                   <a
                     class="underlined"
@@ -977,18 +977,18 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   <span
                     aria-expanded="false"
                     aria-haspopup="menu"
-                    class="wrapper svelte-1x6dshm"
+                    class="wrapper svelte-11prmkk"
                   >
                     <button
-                      class="iconOnly noBorder svelte-1vd9h50"
+                      class="iconOnly noBorder svelte-1e4q28k"
                     >
                       <i
-                        class="material-icons svelte-1vd9h50"
+                        class="material-icons svelte-1e4q28k"
                       >
                         more_vert
                       </i>
@@ -1005,41 +1005,41 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                
             </li>
             <li
-              class="svelte-qra3ls"
+              class="svelte-w3rzzq"
               draggable="true"
             >
               <tr
-                class="svelte-1qu5p5x"
+                class="svelte-1s1441n"
                 slot="item"
               >
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   8
                 </td>
                  
                 <td
-                  class="col-span-6 svelte-1qu5p5x"
+                  class="col-span-6 svelte-1s1441n"
                 >
                   <div
-                    class="undefined root svelte-1wnrcpi"
+                    class="undefined root svelte-30dtyc"
                   >
                     <a
                       class="flex-none"
                       href="#/album/1"
                     >
                       <img
-                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                         height="256"
                         loading="lazy"
                         width="256"
                       />
                        
                       <span
-                        class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                        class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                       >
                         <i
-                          class="material-icons svelte-dtt58s"
+                          class="material-icons svelte-1psk6yi"
                         >
                           music_note
                         </i>
@@ -1048,10 +1048,10 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </a>
                      
                     <div
-                      class="track svelte-1wnrcpi"
+                      class="track svelte-30dtyc"
                     >
                       <span
-                        class="title svelte-1wnrcpi"
+                        class="title svelte-30dtyc"
                       >
                         Bindy
                       </span>
@@ -1076,7 +1076,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </div>
                      
                     <div
-                      class="duration svelte-1wnrcpi"
+                      class="duration svelte-30dtyc"
                     >
                       0:15
                     </div>
@@ -1085,7 +1085,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="col-span-4 svelte-1qu5p5x"
+                  class="col-span-4 svelte-1s1441n"
                 >
                   <a
                     class="underlined"
@@ -1097,18 +1097,18 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   <span
                     aria-expanded="false"
                     aria-haspopup="menu"
-                    class="wrapper svelte-1x6dshm"
+                    class="wrapper svelte-11prmkk"
                   >
                     <button
-                      class="iconOnly noBorder svelte-1vd9h50"
+                      class="iconOnly noBorder svelte-1e4q28k"
                     >
                       <i
-                        class="material-icons svelte-1vd9h50"
+                        class="material-icons svelte-1e4q28k"
                       >
                         more_vert
                       </i>
@@ -1125,41 +1125,41 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                
             </li>
             <li
-              class="svelte-qra3ls"
+              class="svelte-w3rzzq"
               draggable="true"
             >
               <tr
-                class="svelte-1qu5p5x"
+                class="svelte-1s1441n"
                 slot="item"
               >
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   9
                 </td>
                  
                 <td
-                  class="col-span-6 svelte-1qu5p5x"
+                  class="col-span-6 svelte-1s1441n"
                 >
                   <div
-                    class="undefined root svelte-1wnrcpi"
+                    class="undefined root svelte-30dtyc"
                   >
                     <a
                       class="flex-none"
                       href="#/album/1"
                     >
                       <img
-                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                         height="256"
                         loading="lazy"
                         width="256"
                       />
                        
                       <span
-                        class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                        class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                       >
                         <i
-                          class="material-icons svelte-dtt58s"
+                          class="material-icons svelte-1psk6yi"
                         >
                           music_note
                         </i>
@@ -1168,10 +1168,10 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </a>
                      
                     <div
-                      class="track svelte-1wnrcpi"
+                      class="track svelte-30dtyc"
                     >
                       <span
-                        class="title svelte-1wnrcpi"
+                        class="title svelte-30dtyc"
                       >
                         You Make Me Coo
                       </span>
@@ -1196,7 +1196,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </div>
                      
                     <div
-                      class="duration svelte-1wnrcpi"
+                      class="duration svelte-30dtyc"
                     >
                       3:14
                     </div>
@@ -1205,7 +1205,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="col-span-4 svelte-1qu5p5x"
+                  class="col-span-4 svelte-1s1441n"
                 >
                   <a
                     class="underlined"
@@ -1217,18 +1217,18 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   <span
                     aria-expanded="false"
                     aria-haspopup="menu"
-                    class="wrapper svelte-1x6dshm"
+                    class="wrapper svelte-11prmkk"
                   >
                     <button
-                      class="iconOnly noBorder svelte-1vd9h50"
+                      class="iconOnly noBorder svelte-1e4q28k"
                     >
                       <i
-                        class="material-icons svelte-1vd9h50"
+                        class="material-icons svelte-1e4q28k"
                       >
                         more_vert
                       </i>
@@ -1245,41 +1245,41 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                
             </li>
             <li
-              class="svelte-qra3ls"
+              class="svelte-w3rzzq"
               draggable="true"
             >
               <tr
-                class="svelte-1qu5p5x"
+                class="svelte-1s1441n"
                 slot="item"
               >
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   10
                 </td>
                  
                 <td
-                  class="col-span-6 svelte-1qu5p5x"
+                  class="col-span-6 svelte-1s1441n"
                 >
                   <div
-                    class="undefined root svelte-1wnrcpi"
+                    class="undefined root svelte-30dtyc"
                   >
                     <a
                       class="flex-none"
                       href="#/album/1"
                     >
                       <img
-                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                         height="256"
                         loading="lazy"
                         width="256"
                       />
                        
                       <span
-                        class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                        class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                       >
                         <i
-                          class="material-icons svelte-dtt58s"
+                          class="material-icons svelte-1psk6yi"
                         >
                           music_note
                         </i>
@@ -1288,10 +1288,10 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </a>
                      
                     <div
-                      class="track svelte-1wnrcpi"
+                      class="track svelte-30dtyc"
                     >
                       <span
-                        class="title svelte-1wnrcpi"
+                        class="title svelte-30dtyc"
                       >
                         Vitamin B
                       </span>
@@ -1316,7 +1316,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </div>
                      
                     <div
-                      class="duration svelte-1wnrcpi"
+                      class="duration svelte-30dtyc"
                     >
                       4:06
                     </div>
@@ -1325,7 +1325,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="col-span-4 svelte-1qu5p5x"
+                  class="col-span-4 svelte-1s1441n"
                 >
                   <a
                     class="underlined"
@@ -1337,18 +1337,18 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   <span
                     aria-expanded="false"
                     aria-haspopup="menu"
-                    class="wrapper svelte-1x6dshm"
+                    class="wrapper svelte-11prmkk"
                   >
                     <button
-                      class="iconOnly noBorder svelte-1vd9h50"
+                      class="iconOnly noBorder svelte-1e4q28k"
                     >
                       <i
-                        class="material-icons svelte-1vd9h50"
+                        class="material-icons svelte-1e4q28k"
                       >
                         more_vert
                       </i>
@@ -1365,41 +1365,41 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                
             </li>
             <li
-              class="svelte-qra3ls"
+              class="svelte-w3rzzq"
               draggable="true"
             >
               <tr
-                class="svelte-1qu5p5x"
+                class="svelte-1s1441n"
                 slot="item"
               >
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   11
                 </td>
                  
                 <td
-                  class="col-span-6 svelte-1qu5p5x"
+                  class="col-span-6 svelte-1s1441n"
                 >
                   <div
-                    class="undefined root svelte-1wnrcpi"
+                    class="undefined root svelte-30dtyc"
                   >
                     <a
                       class="flex-none"
                       href="#/album/1"
                     >
                       <img
-                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                         height="256"
                         loading="lazy"
                         width="256"
                       />
                        
                       <span
-                        class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                        class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                       >
                         <i
-                          class="material-icons svelte-dtt58s"
+                          class="material-icons svelte-1psk6yi"
                         >
                           music_note
                         </i>
@@ -1408,10 +1408,10 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </a>
                      
                     <div
-                      class="track svelte-1wnrcpi"
+                      class="track svelte-30dtyc"
                     >
                       <span
-                        class="title svelte-1wnrcpi"
+                        class="title svelte-30dtyc"
                       >
                         Green Bird
                       </span>
@@ -1436,7 +1436,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </div>
                      
                     <div
-                      class="duration svelte-1wnrcpi"
+                      class="duration svelte-30dtyc"
                     >
                       2:33
                     </div>
@@ -1445,7 +1445,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="col-span-4 svelte-1qu5p5x"
+                  class="col-span-4 svelte-1s1441n"
                 >
                   <a
                     class="underlined"
@@ -1457,18 +1457,18 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   <span
                     aria-expanded="false"
                     aria-haspopup="menu"
-                    class="wrapper svelte-1x6dshm"
+                    class="wrapper svelte-11prmkk"
                   >
                     <button
-                      class="iconOnly noBorder svelte-1vd9h50"
+                      class="iconOnly noBorder svelte-1e4q28k"
                     >
                       <i
-                        class="material-icons svelte-1vd9h50"
+                        class="material-icons svelte-1e4q28k"
                       >
                         more_vert
                       </i>
@@ -1485,41 +1485,41 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                
             </li>
             <li
-              class="svelte-qra3ls"
+              class="svelte-w3rzzq"
               draggable="true"
             >
               <tr
-                class="svelte-1qu5p5x"
+                class="svelte-1s1441n"
                 slot="item"
               >
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   12
                 </td>
                  
                 <td
-                  class="col-span-6 svelte-1qu5p5x"
+                  class="col-span-6 svelte-1s1441n"
                 >
                   <div
-                    class="undefined root svelte-1wnrcpi"
+                    class="undefined root svelte-30dtyc"
                   >
                     <a
                       class="flex-none"
                       href="#/album/1"
                     >
                       <img
-                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                         height="256"
                         loading="lazy"
                         width="256"
                       />
                        
                       <span
-                        class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                        class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                       >
                         <i
-                          class="material-icons svelte-dtt58s"
+                          class="material-icons svelte-1psk6yi"
                         >
                           music_note
                         </i>
@@ -1528,10 +1528,10 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </a>
                      
                     <div
-                      class="track svelte-1wnrcpi"
+                      class="track svelte-30dtyc"
                     >
                       <span
-                        class="title svelte-1wnrcpi"
+                        class="title svelte-30dtyc"
                       >
                         ELM
                       </span>
@@ -1556,7 +1556,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </div>
                      
                     <div
-                      class="duration svelte-1wnrcpi"
+                      class="duration svelte-30dtyc"
                     >
                       6:55
                     </div>
@@ -1565,7 +1565,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="col-span-4 svelte-1qu5p5x"
+                  class="col-span-4 svelte-1s1441n"
                 >
                   <a
                     class="underlined"
@@ -1577,18 +1577,18 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   <span
                     aria-expanded="false"
                     aria-haspopup="menu"
-                    class="wrapper svelte-1x6dshm"
+                    class="wrapper svelte-11prmkk"
                   >
                     <button
-                      class="iconOnly noBorder svelte-1vd9h50"
+                      class="iconOnly noBorder svelte-1e4q28k"
                     >
                       <i
-                        class="material-icons svelte-1vd9h50"
+                        class="material-icons svelte-1e4q28k"
                       >
                         more_vert
                       </i>
@@ -1605,41 +1605,41 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                
             </li>
             <li
-              class="svelte-qra3ls"
+              class="svelte-w3rzzq"
               draggable="true"
             >
               <tr
-                class="svelte-1qu5p5x"
+                class="svelte-1s1441n"
                 slot="item"
               >
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   13
                 </td>
                  
                 <td
-                  class="col-span-6 svelte-1qu5p5x"
+                  class="col-span-6 svelte-1s1441n"
                 >
                   <div
-                    class="undefined root svelte-1wnrcpi"
+                    class="undefined root svelte-30dtyc"
                   >
                     <a
                       class="flex-none"
                       href="#/album/1"
                     >
                       <img
-                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                         height="256"
                         loading="lazy"
                         width="256"
                       />
                        
                       <span
-                        class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                        class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                       >
                         <i
-                          class="material-icons svelte-dtt58s"
+                          class="material-icons svelte-1psk6yi"
                         >
                           music_note
                         </i>
@@ -1648,10 +1648,10 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </a>
                      
                     <div
-                      class="track svelte-1wnrcpi"
+                      class="track svelte-30dtyc"
                     >
                       <span
-                        class="title svelte-1wnrcpi"
+                        class="title svelte-30dtyc"
                       >
                         Vitamin C
                       </span>
@@ -1676,7 +1676,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </div>
                      
                     <div
-                      class="duration svelte-1wnrcpi"
+                      class="duration svelte-30dtyc"
                     >
                       5:24
                     </div>
@@ -1685,7 +1685,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="col-span-4 svelte-1qu5p5x"
+                  class="col-span-4 svelte-1s1441n"
                 >
                   <a
                     class="underlined"
@@ -1697,18 +1697,18 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   <span
                     aria-expanded="false"
                     aria-haspopup="menu"
-                    class="wrapper svelte-1x6dshm"
+                    class="wrapper svelte-11prmkk"
                   >
                     <button
-                      class="iconOnly noBorder svelte-1vd9h50"
+                      class="iconOnly noBorder svelte-1e4q28k"
                     >
                       <i
-                        class="material-icons svelte-1vd9h50"
+                        class="material-icons svelte-1e4q28k"
                       >
                         more_vert
                       </i>
@@ -1725,41 +1725,41 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                
             </li>
             <li
-              class="svelte-qra3ls"
+              class="svelte-w3rzzq"
               draggable="true"
             >
               <tr
-                class="svelte-1qu5p5x"
+                class="svelte-1s1441n"
                 slot="item"
               >
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   14
                 </td>
                  
                 <td
-                  class="col-span-6 svelte-1qu5p5x"
+                  class="col-span-6 svelte-1s1441n"
                 >
                   <div
-                    class="undefined root svelte-1wnrcpi"
+                    class="undefined root svelte-30dtyc"
                   >
                     <a
                       class="flex-none"
                       href="#/album/1"
                     >
                       <img
-                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                         height="256"
                         loading="lazy"
                         width="256"
                       />
                        
                       <span
-                        class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                        class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                       >
                         <i
-                          class="material-icons svelte-dtt58s"
+                          class="material-icons svelte-1psk6yi"
                         >
                           music_note
                         </i>
@@ -1768,10 +1768,10 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </a>
                      
                     <div
-                      class="track svelte-1wnrcpi"
+                      class="track svelte-30dtyc"
                     >
                       <span
-                        class="title svelte-1wnrcpi"
+                        class="title svelte-30dtyc"
                       >
                         Gateway
                       </span>
@@ -1796,7 +1796,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </div>
                      
                     <div
-                      class="duration svelte-1wnrcpi"
+                      class="duration svelte-30dtyc"
                     >
                       0:16
                     </div>
@@ -1805,7 +1805,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="col-span-4 svelte-1qu5p5x"
+                  class="col-span-4 svelte-1s1441n"
                 >
                   <a
                     class="underlined"
@@ -1817,18 +1817,18 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   <span
                     aria-expanded="false"
                     aria-haspopup="menu"
-                    class="wrapper svelte-1x6dshm"
+                    class="wrapper svelte-11prmkk"
                   >
                     <button
-                      class="iconOnly noBorder svelte-1vd9h50"
+                      class="iconOnly noBorder svelte-1e4q28k"
                     >
                       <i
-                        class="material-icons svelte-1vd9h50"
+                        class="material-icons svelte-1e4q28k"
                       >
                         more_vert
                       </i>
@@ -1845,41 +1845,41 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                
             </li>
             <li
-              class="svelte-qra3ls"
+              class="svelte-w3rzzq"
               draggable="true"
             >
               <tr
-                class="svelte-1qu5p5x"
+                class="svelte-1s1441n"
                 slot="item"
               >
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   15
                 </td>
                  
                 <td
-                  class="col-span-6 svelte-1qu5p5x"
+                  class="col-span-6 svelte-1s1441n"
                 >
                   <div
-                    class="undefined root svelte-1wnrcpi"
+                    class="undefined root svelte-30dtyc"
                   >
                     <a
                       class="flex-none"
                       href="#/album/1"
                     >
                       <img
-                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                         height="256"
                         loading="lazy"
                         width="256"
                       />
                        
                       <span
-                        class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                        class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                       >
                         <i
-                          class="material-icons svelte-dtt58s"
+                          class="material-icons svelte-1psk6yi"
                         >
                           music_note
                         </i>
@@ -1888,10 +1888,10 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </a>
                      
                     <div
-                      class="track svelte-1wnrcpi"
+                      class="track svelte-30dtyc"
                     >
                       <span
-                        class="title svelte-1wnrcpi"
+                        class="title svelte-30dtyc"
                       >
                         The Singing Sea
                       </span>
@@ -1916,7 +1916,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </div>
                      
                     <div
-                      class="duration svelte-1wnrcpi"
+                      class="duration svelte-30dtyc"
                     >
                       6:41
                     </div>
@@ -1925,7 +1925,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="col-span-4 svelte-1qu5p5x"
+                  class="col-span-4 svelte-1s1441n"
                 >
                   <a
                     class="underlined"
@@ -1937,18 +1937,18 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   <span
                     aria-expanded="false"
                     aria-haspopup="menu"
-                    class="wrapper svelte-1x6dshm"
+                    class="wrapper svelte-11prmkk"
                   >
                     <button
-                      class="iconOnly noBorder svelte-1vd9h50"
+                      class="iconOnly noBorder svelte-1e4q28k"
                     >
                       <i
-                        class="material-icons svelte-1vd9h50"
+                        class="material-icons svelte-1e4q28k"
                       >
                         more_vert
                       </i>
@@ -1965,41 +1965,41 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                
             </li>
             <li
-              class="svelte-qra3ls"
+              class="svelte-w3rzzq"
               draggable="true"
             >
               <tr
-                class="svelte-1qu5p5x"
+                class="svelte-1s1441n"
                 slot="item"
               >
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   16
                 </td>
                  
                 <td
-                  class="col-span-6 svelte-1qu5p5x"
+                  class="col-span-6 svelte-1s1441n"
                 >
                   <div
-                    class="undefined root svelte-1wnrcpi"
+                    class="undefined root svelte-30dtyc"
                   >
                     <a
                       class="flex-none"
                       href="#/album/1"
                     >
                       <img
-                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                         height="256"
                         loading="lazy"
                         width="256"
                       />
                        
                       <span
-                        class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                        class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                       >
                         <i
-                          class="material-icons svelte-dtt58s"
+                          class="material-icons svelte-1psk6yi"
                         >
                           music_note
                         </i>
@@ -2008,10 +2008,10 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </a>
                      
                     <div
-                      class="track svelte-1wnrcpi"
+                      class="track svelte-30dtyc"
                     >
                       <span
-                        class="title svelte-1wnrcpi"
+                        class="title svelte-30dtyc"
                       >
                         The Egg and You!
                       </span>
@@ -2036,7 +2036,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </div>
                      
                     <div
-                      class="duration svelte-1wnrcpi"
+                      class="duration svelte-30dtyc"
                     >
                       4:47
                     </div>
@@ -2045,7 +2045,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="col-span-4 svelte-1qu5p5x"
+                  class="col-span-4 svelte-1s1441n"
                 >
                   <a
                     class="underlined"
@@ -2057,18 +2057,18 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   <span
                     aria-expanded="false"
                     aria-haspopup="menu"
-                    class="wrapper svelte-1x6dshm"
+                    class="wrapper svelte-11prmkk"
                   >
                     <button
-                      class="iconOnly noBorder svelte-1vd9h50"
+                      class="iconOnly noBorder svelte-1e4q28k"
                     >
                       <i
-                        class="material-icons svelte-1vd9h50"
+                        class="material-icons svelte-1e4q28k"
                       >
                         more_vert
                       </i>
@@ -2085,41 +2085,41 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                
             </li>
             <li
-              class="svelte-qra3ls"
+              class="svelte-w3rzzq"
               draggable="true"
             >
               <tr
-                class="svelte-1qu5p5x"
+                class="svelte-1s1441n"
                 slot="item"
               >
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   17
                 </td>
                  
                 <td
-                  class="col-span-6 svelte-1qu5p5x"
+                  class="col-span-6 svelte-1s1441n"
                 >
                   <div
-                    class="undefined root svelte-1wnrcpi"
+                    class="undefined root svelte-30dtyc"
                   >
                     <a
                       class="flex-none"
                       href="#/album/1"
                     >
                       <img
-                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                         height="256"
                         loading="lazy"
                         width="256"
                       />
                        
                       <span
-                        class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                        class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                       >
                         <i
-                          class="material-icons svelte-dtt58s"
+                          class="material-icons svelte-1psk6yi"
                         >
                           music_note
                         </i>
@@ -2128,10 +2128,10 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </a>
                      
                     <div
-                      class="track svelte-1wnrcpi"
+                      class="track svelte-30dtyc"
                     >
                       <span
-                        class="title svelte-1wnrcpi"
+                        class="title svelte-30dtyc"
                       >
                         Forever Broke
                       </span>
@@ -2156,7 +2156,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </div>
                      
                     <div
-                      class="duration svelte-1wnrcpi"
+                      class="duration svelte-30dtyc"
                     >
                       1:36
                     </div>
@@ -2165,7 +2165,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="col-span-4 svelte-1qu5p5x"
+                  class="col-span-4 svelte-1s1441n"
                 >
                   <a
                     class="underlined"
@@ -2177,18 +2177,18 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   <span
                     aria-expanded="false"
                     aria-haspopup="menu"
-                    class="wrapper svelte-1x6dshm"
+                    class="wrapper svelte-11prmkk"
                   >
                     <button
-                      class="iconOnly noBorder svelte-1vd9h50"
+                      class="iconOnly noBorder svelte-1e4q28k"
                     >
                       <i
-                        class="material-icons svelte-1vd9h50"
+                        class="material-icons svelte-1e4q28k"
                       >
                         more_vert
                       </i>
@@ -2205,41 +2205,41 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                
             </li>
             <li
-              class="svelte-qra3ls"
+              class="svelte-w3rzzq"
               draggable="true"
             >
               <tr
-                class="svelte-1qu5p5x"
+                class="svelte-1s1441n"
                 slot="item"
               >
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   18
                 </td>
                  
                 <td
-                  class="col-span-6 svelte-1qu5p5x"
+                  class="col-span-6 svelte-1s1441n"
                 >
                   <div
-                    class="undefined root svelte-1wnrcpi"
+                    class="undefined root svelte-30dtyc"
                   >
                     <a
                       class="flex-none"
                       href="#/album/1"
                     >
                       <img
-                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                        class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                         height="256"
                         loading="lazy"
                         width="256"
                       />
                        
                       <span
-                        class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                        class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                       >
                         <i
-                          class="material-icons svelte-dtt58s"
+                          class="material-icons svelte-1psk6yi"
                         >
                           music_note
                         </i>
@@ -2248,10 +2248,10 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </a>
                      
                     <div
-                      class="track svelte-1wnrcpi"
+                      class="track svelte-30dtyc"
                     >
                       <span
-                        class="title svelte-1wnrcpi"
+                        class="title svelte-30dtyc"
                       >
                         Power of Kungfu Remix
                       </span>
@@ -2276,7 +2276,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                     </div>
                      
                     <div
-                      class="duration svelte-1wnrcpi"
+                      class="duration svelte-30dtyc"
                     >
                       2:22
                     </div>
@@ -2285,7 +2285,7 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="col-span-4 svelte-1qu5p5x"
+                  class="col-span-4 svelte-1s1441n"
                 >
                   <a
                     class="underlined"
@@ -2297,18 +2297,18 @@ exports[`Toolshot routes/playlist/[id].tools.svelte: Views/Playlist Details 1`] 
                 </td>
                  
                 <td
-                  class="svelte-1qu5p5x"
+                  class="svelte-1s1441n"
                 >
                   <span
                     aria-expanded="false"
                     aria-haspopup="menu"
-                    class="wrapper svelte-1x6dshm"
+                    class="wrapper svelte-11prmkk"
                   >
                     <button
-                      class="iconOnly noBorder svelte-1vd9h50"
+                      class="iconOnly noBorder svelte-1e4q28k"
                     >
                       <i
-                        class="material-icons svelte-1vd9h50"
+                        class="material-icons svelte-1e4q28k"
                       >
                         more_vert
                       </i>

--- a/common/ui/src/routes/search/__snapshots__/[searched].tools.shot
+++ b/common/ui/src/routes/search/__snapshots__/[searched].tools.shot
@@ -8,11 +8,11 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
     style="animation: __svelte_185617033_0 200ms linear 0ms 1 both;"
   >
     <header
-      class=" svelte-8800qh"
+      class=" svelte-t58ezf"
       style="--image: url(../images/anthony-martino-6AtQNsjMoJo-unsplash.jpg); --shade-color: rgba(0, 0, 0, 0.7); --bgPosition: bottom center;"
     >
       <h1
-        class="svelte-8800qh"
+        class="svelte-t58ezf"
       >
         Results for "Final Fantasy VII"
       </h1>
@@ -20,42 +20,42 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
      
      
     <section
-      class="svelte-jajdg"
+      class="svelte-1bpty66"
     >
       <span
-        class="undefined tracks svelte-uiewq8"
+        class="undefined tracks svelte-1kobtom"
       >
         <h3
-          class="svelte-uiewq8"
+          class="svelte-1kobtom"
         >
           18 tracks
         </h3>
          
         <ul
-          class="svelte-uiewq8"
+          class="svelte-1kobtom"
         >
           <li
-            class="svelte-uiewq8"
+            class="svelte-1kobtom"
           >
             <div
-              class="undefined root svelte-1wnrcpi"
+              class="undefined root svelte-30dtyc"
             >
               <a
                 class="flex-none"
                 href="#/album/1"
               >
                 <img
-                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                   height="256"
                   loading="lazy"
                   width="256"
                 />
                  
                 <span
-                  class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                  class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                 >
                   <i
-                    class="material-icons svelte-dtt58s"
+                    class="material-icons svelte-1psk6yi"
                   >
                     music_note
                   </i>
@@ -64,10 +64,10 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               </a>
                
               <div
-                class="track svelte-1wnrcpi"
+                class="track svelte-30dtyc"
               >
                 <span
-                  class="title svelte-1wnrcpi"
+                  class="title svelte-30dtyc"
                 >
                   American Money
                 </span>
@@ -95,13 +95,13 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -117,27 +117,27 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
              
           </li>
           <li
-            class="svelte-uiewq8"
+            class="svelte-1kobtom"
           >
             <div
-              class="undefined root svelte-1wnrcpi"
+              class="undefined root svelte-30dtyc"
             >
               <a
                 class="flex-none"
                 href="#/album/1"
               >
                 <img
-                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                   height="256"
                   loading="lazy"
                   width="256"
                 />
                  
                 <span
-                  class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                  class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                 >
                   <i
-                    class="material-icons svelte-dtt58s"
+                    class="material-icons svelte-1psk6yi"
                   >
                     music_note
                   </i>
@@ -146,10 +146,10 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               </a>
                
               <div
-                class="track svelte-1wnrcpi"
+                class="track svelte-30dtyc"
               >
                 <span
-                  class="title svelte-1wnrcpi"
+                  class="title svelte-30dtyc"
                 >
                   Bindy
                 </span>
@@ -177,13 +177,13 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -199,27 +199,27 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
              
           </li>
           <li
-            class="svelte-uiewq8"
+            class="svelte-1kobtom"
           >
             <div
-              class="undefined root svelte-1wnrcpi"
+              class="undefined root svelte-30dtyc"
             >
               <a
                 class="flex-none"
                 href="#/album/1"
               >
                 <img
-                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                   height="256"
                   loading="lazy"
                   width="256"
                 />
                  
                 <span
-                  class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                  class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                 >
                   <i
-                    class="material-icons svelte-dtt58s"
+                    class="material-icons svelte-1psk6yi"
                   >
                     music_note
                   </i>
@@ -228,10 +228,10 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               </a>
                
               <div
-                class="track svelte-1wnrcpi"
+                class="track svelte-30dtyc"
               >
                 <span
-                  class="title svelte-1wnrcpi"
+                  class="title svelte-30dtyc"
                 >
                   Cats on Mars
                 </span>
@@ -259,13 +259,13 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -281,27 +281,27 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
              
           </li>
           <li
-            class="svelte-uiewq8"
+            class="svelte-1kobtom"
           >
             <div
-              class="undefined root svelte-1wnrcpi"
+              class="undefined root svelte-30dtyc"
             >
               <a
                 class="flex-none"
                 href="#/album/1"
               >
                 <img
-                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                   height="256"
                   loading="lazy"
                   width="256"
                 />
                  
                 <span
-                  class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                  class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                 >
                   <i
-                    class="material-icons svelte-dtt58s"
+                    class="material-icons svelte-1psk6yi"
                   >
                     music_note
                   </i>
@@ -310,10 +310,10 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               </a>
                
               <div
-                class="track svelte-1wnrcpi"
+                class="track svelte-30dtyc"
               >
                 <span
-                  class="title svelte-1wnrcpi"
+                  class="title svelte-30dtyc"
                 >
                   Don't Bother None
                 </span>
@@ -341,13 +341,13 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -363,27 +363,27 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
              
           </li>
           <li
-            class="svelte-uiewq8"
+            class="svelte-1kobtom"
           >
             <div
-              class="undefined root svelte-1wnrcpi"
+              class="undefined root svelte-30dtyc"
             >
               <a
                 class="flex-none"
                 href="#/album/1"
               >
                 <img
-                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                   height="256"
                   loading="lazy"
                   width="256"
                 />
                  
                 <span
-                  class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                  class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                 >
                   <i
-                    class="material-icons svelte-dtt58s"
+                    class="material-icons svelte-1psk6yi"
                   >
                     music_note
                   </i>
@@ -392,10 +392,10 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               </a>
                
               <div
-                class="track svelte-1wnrcpi"
+                class="track svelte-30dtyc"
               >
                 <span
-                  class="title svelte-1wnrcpi"
+                  class="title svelte-30dtyc"
                 >
                   ELM
                 </span>
@@ -423,13 +423,13 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -445,27 +445,27 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
              
           </li>
           <li
-            class="svelte-uiewq8"
+            class="svelte-1kobtom"
           >
             <div
-              class="undefined root svelte-1wnrcpi"
+              class="undefined root svelte-30dtyc"
             >
               <a
                 class="flex-none"
                 href="#/album/1"
               >
                 <img
-                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                   height="256"
                   loading="lazy"
                   width="256"
                 />
                  
                 <span
-                  class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                  class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                 >
                   <i
-                    class="material-icons svelte-dtt58s"
+                    class="material-icons svelte-1psk6yi"
                   >
                     music_note
                   </i>
@@ -474,10 +474,10 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               </a>
                
               <div
-                class="track svelte-1wnrcpi"
+                class="track svelte-30dtyc"
               >
                 <span
-                  class="title svelte-1wnrcpi"
+                  class="title svelte-30dtyc"
                 >
                   Fantaisie Sign
                 </span>
@@ -505,13 +505,13 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -527,27 +527,27 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
              
           </li>
           <li
-            class="svelte-uiewq8"
+            class="svelte-1kobtom"
           >
             <div
-              class="undefined root svelte-1wnrcpi"
+              class="undefined root svelte-30dtyc"
             >
               <a
                 class="flex-none"
                 href="#/album/1"
               >
                 <img
-                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                   height="256"
                   loading="lazy"
                   width="256"
                 />
                  
                 <span
-                  class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                  class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                 >
                   <i
-                    class="material-icons svelte-dtt58s"
+                    class="material-icons svelte-1psk6yi"
                   >
                     music_note
                   </i>
@@ -556,10 +556,10 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               </a>
                
               <div
-                class="track svelte-1wnrcpi"
+                class="track svelte-30dtyc"
               >
                 <span
-                  class="title svelte-1wnrcpi"
+                  class="title svelte-30dtyc"
                 >
                   Forever Broke
                 </span>
@@ -587,13 +587,13 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -609,27 +609,27 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
              
           </li>
           <li
-            class="svelte-uiewq8"
+            class="svelte-1kobtom"
           >
             <div
-              class="undefined root svelte-1wnrcpi"
+              class="undefined root svelte-30dtyc"
             >
               <a
                 class="flex-none"
                 href="#/album/1"
               >
                 <img
-                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                   height="256"
                   loading="lazy"
                   width="256"
                 />
                  
                 <span
-                  class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                  class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                 >
                   <i
-                    class="material-icons svelte-dtt58s"
+                    class="material-icons svelte-1psk6yi"
                   >
                     music_note
                   </i>
@@ -638,10 +638,10 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               </a>
                
               <div
-                class="track svelte-1wnrcpi"
+                class="track svelte-30dtyc"
               >
                 <span
-                  class="title svelte-1wnrcpi"
+                  class="title svelte-30dtyc"
                 >
                   Gateway
                 </span>
@@ -669,13 +669,13 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -691,27 +691,27 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
              
           </li>
           <li
-            class="svelte-uiewq8"
+            class="svelte-1kobtom"
           >
             <div
-              class="undefined root svelte-1wnrcpi"
+              class="undefined root svelte-30dtyc"
             >
               <a
                 class="flex-none"
                 href="#/album/1"
               >
                 <img
-                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                   height="256"
                   loading="lazy"
                   width="256"
                 />
                  
                 <span
-                  class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                  class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                 >
                   <i
-                    class="material-icons svelte-dtt58s"
+                    class="material-icons svelte-1psk6yi"
                   >
                     music_note
                   </i>
@@ -720,10 +720,10 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               </a>
                
               <div
-                class="track svelte-1wnrcpi"
+                class="track svelte-30dtyc"
               >
                 <span
-                  class="title svelte-1wnrcpi"
+                  class="title svelte-30dtyc"
                 >
                   Green Bird
                 </span>
@@ -751,13 +751,13 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -773,27 +773,27 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
              
           </li>
           <li
-            class="svelte-uiewq8"
+            class="svelte-1kobtom"
           >
             <div
-              class="undefined root svelte-1wnrcpi"
+              class="undefined root svelte-30dtyc"
             >
               <a
                 class="flex-none"
                 href="#/album/1"
               >
                 <img
-                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                   height="256"
                   loading="lazy"
                   width="256"
                 />
                  
                 <span
-                  class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                  class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                 >
                   <i
-                    class="material-icons svelte-dtt58s"
+                    class="material-icons svelte-1psk6yi"
                   >
                     music_note
                   </i>
@@ -802,10 +802,10 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               </a>
                
               <div
-                class="track svelte-1wnrcpi"
+                class="track svelte-30dtyc"
               >
                 <span
-                  class="title svelte-1wnrcpi"
+                  class="title svelte-30dtyc"
                 >
                   LIVE in Baghdad
                 </span>
@@ -833,13 +833,13 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -855,27 +855,27 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
              
           </li>
           <li
-            class="svelte-uiewq8"
+            class="svelte-1kobtom"
           >
             <div
-              class="undefined root svelte-1wnrcpi"
+              class="undefined root svelte-30dtyc"
             >
               <a
                 class="flex-none"
                 href="#/album/1"
               >
                 <img
-                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                   height="256"
                   loading="lazy"
                   width="256"
                 />
                  
                 <span
-                  class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                  class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                 >
                   <i
-                    class="material-icons svelte-dtt58s"
+                    class="material-icons svelte-1psk6yi"
                   >
                     music_note
                   </i>
@@ -884,10 +884,10 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               </a>
                
               <div
-                class="track svelte-1wnrcpi"
+                class="track svelte-30dtyc"
               >
                 <span
-                  class="title svelte-1wnrcpi"
+                  class="title svelte-30dtyc"
                 >
                   Power of Kungfu Remix
                 </span>
@@ -915,13 +915,13 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -937,27 +937,27 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
              
           </li>
           <li
-            class="svelte-uiewq8"
+            class="svelte-1kobtom"
           >
             <div
-              class="undefined root svelte-1wnrcpi"
+              class="undefined root svelte-30dtyc"
             >
               <a
                 class="flex-none"
                 href="#/album/1"
               >
                 <img
-                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                   height="256"
                   loading="lazy"
                   width="256"
                 />
                  
                 <span
-                  class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                  class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                 >
                   <i
-                    class="material-icons svelte-dtt58s"
+                    class="material-icons svelte-1psk6yi"
                   >
                     music_note
                   </i>
@@ -966,10 +966,10 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               </a>
                
               <div
-                class="track svelte-1wnrcpi"
+                class="track svelte-30dtyc"
               >
                 <span
-                  class="title svelte-1wnrcpi"
+                  class="title svelte-30dtyc"
                 >
                   The Egg and You!
                 </span>
@@ -997,13 +997,13 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -1019,27 +1019,27 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
              
           </li>
           <li
-            class="svelte-uiewq8"
+            class="svelte-1kobtom"
           >
             <div
-              class="undefined root svelte-1wnrcpi"
+              class="undefined root svelte-30dtyc"
             >
               <a
                 class="flex-none"
                 href="#/album/1"
               >
                 <img
-                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                   height="256"
                   loading="lazy"
                   width="256"
                 />
                  
                 <span
-                  class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                  class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                 >
                   <i
-                    class="material-icons svelte-dtt58s"
+                    class="material-icons svelte-1psk6yi"
                   >
                     music_note
                   </i>
@@ -1048,10 +1048,10 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               </a>
                
               <div
-                class="track svelte-1wnrcpi"
+                class="track svelte-30dtyc"
               >
                 <span
-                  class="title svelte-1wnrcpi"
+                  class="title svelte-30dtyc"
                 >
                   The Singing Sea
                 </span>
@@ -1079,13 +1079,13 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -1101,27 +1101,27 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
              
           </li>
           <li
-            class="svelte-uiewq8"
+            class="svelte-1kobtom"
           >
             <div
-              class="undefined root svelte-1wnrcpi"
+              class="undefined root svelte-30dtyc"
             >
               <a
                 class="flex-none"
                 href="#/album/1"
               >
                 <img
-                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                   height="256"
                   loading="lazy"
                   width="256"
                 />
                  
                 <span
-                  class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                  class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                 >
                   <i
-                    class="material-icons svelte-dtt58s"
+                    class="material-icons svelte-1psk6yi"
                   >
                     music_note
                   </i>
@@ -1130,10 +1130,10 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               </a>
                
               <div
-                class="track svelte-1wnrcpi"
+                class="track svelte-30dtyc"
               >
                 <span
-                  class="title svelte-1wnrcpi"
+                  class="title svelte-30dtyc"
                 >
                   Vitamin A
                 </span>
@@ -1161,13 +1161,13 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -1183,27 +1183,27 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
              
           </li>
           <li
-            class="svelte-uiewq8"
+            class="svelte-1kobtom"
           >
             <div
-              class="undefined root svelte-1wnrcpi"
+              class="undefined root svelte-30dtyc"
             >
               <a
                 class="flex-none"
                 href="#/album/1"
               >
                 <img
-                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                   height="256"
                   loading="lazy"
                   width="256"
                 />
                  
                 <span
-                  class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                  class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                 >
                   <i
-                    class="material-icons svelte-dtt58s"
+                    class="material-icons svelte-1psk6yi"
                   >
                     music_note
                   </i>
@@ -1212,10 +1212,10 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               </a>
                
               <div
-                class="track svelte-1wnrcpi"
+                class="track svelte-30dtyc"
               >
                 <span
-                  class="title svelte-1wnrcpi"
+                  class="title svelte-30dtyc"
                 >
                   Vitamin B
                 </span>
@@ -1243,13 +1243,13 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -1265,27 +1265,27 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
              
           </li>
           <li
-            class="svelte-uiewq8"
+            class="svelte-1kobtom"
           >
             <div
-              class="undefined root svelte-1wnrcpi"
+              class="undefined root svelte-30dtyc"
             >
               <a
                 class="flex-none"
                 href="#/album/1"
               >
                 <img
-                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                   height="256"
                   loading="lazy"
                   width="256"
                 />
                  
                 <span
-                  class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                  class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                 >
                   <i
-                    class="material-icons svelte-dtt58s"
+                    class="material-icons svelte-1psk6yi"
                   >
                     music_note
                   </i>
@@ -1294,10 +1294,10 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               </a>
                
               <div
-                class="track svelte-1wnrcpi"
+                class="track svelte-30dtyc"
               >
                 <span
-                  class="title svelte-1wnrcpi"
+                  class="title svelte-30dtyc"
                 >
                   Vitamin C
                 </span>
@@ -1325,13 +1325,13 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -1347,27 +1347,27 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
              
           </li>
           <li
-            class="svelte-uiewq8"
+            class="svelte-1kobtom"
           >
             <div
-              class="undefined root svelte-1wnrcpi"
+              class="undefined root svelte-30dtyc"
             >
               <a
                 class="flex-none"
                 href="#/album/1"
               >
                 <img
-                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                   height="256"
                   loading="lazy"
                   width="256"
                 />
                  
                 <span
-                  class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                  class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                 >
                   <i
-                    class="material-icons svelte-dtt58s"
+                    class="material-icons svelte-1psk6yi"
                   >
                     music_note
                   </i>
@@ -1376,10 +1376,10 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               </a>
                
               <div
-                class="track svelte-1wnrcpi"
+                class="track svelte-30dtyc"
               >
                 <span
-                  class="title svelte-1wnrcpi"
+                  class="title svelte-30dtyc"
                 >
                   Want it All Back
                 </span>
@@ -1407,13 +1407,13 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -1429,27 +1429,27 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
              
           </li>
           <li
-            class="svelte-uiewq8"
+            class="svelte-1kobtom"
           >
             <div
-              class="undefined root svelte-1wnrcpi"
+              class="undefined root svelte-30dtyc"
             >
               <a
                 class="flex-none"
                 href="#/album/1"
               >
                 <img
-                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-dtt58s"
+                  class="h-16 w-16 text-xs actionable rounded-sm hidden svelte-1psk6yi"
                   height="256"
                   loading="lazy"
                   width="256"
                 />
                  
                 <span
-                  class="h-16 w-16 text-xs actionable svelte-dtt58s rounded-sm"
+                  class="h-16 w-16 text-xs actionable svelte-1psk6yi rounded-sm"
                 >
                   <i
-                    class="material-icons svelte-dtt58s"
+                    class="material-icons svelte-1psk6yi"
                   >
                     music_note
                   </i>
@@ -1458,10 +1458,10 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               </a>
                
               <div
-                class="track svelte-1wnrcpi"
+                class="track svelte-30dtyc"
               >
                 <span
-                  class="title svelte-1wnrcpi"
+                  class="title svelte-30dtyc"
                 >
                   You Make Me Coo
                 </span>
@@ -1489,13 +1489,13 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               <span
                 aria-expanded="false"
                 aria-haspopup="menu"
-                class="wrapper svelte-1x6dshm"
+                class="wrapper svelte-11prmkk"
               >
                 <button
-                  class="iconOnly noBorder svelte-1vd9h50"
+                  class="iconOnly noBorder svelte-1e4q28k"
                 >
                   <i
-                    class="material-icons svelte-1vd9h50"
+                    class="material-icons svelte-1e4q28k"
                   >
                     more_vert
                   </i>
@@ -1523,46 +1523,46 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
     </section>
      
     <section
-      class="svelte-jajdg"
+      class="svelte-1bpty66"
     >
       <span
-        class="undefined artists svelte-uiewq8"
+        class="undefined artists svelte-1kobtom"
       >
         <h3
-          class="svelte-uiewq8"
+          class="svelte-1kobtom"
         >
           3 artists
         </h3>
          
         <ul
-          class="svelte-uiewq8"
+          class="svelte-1kobtom"
         >
           <li
-            class="svelte-uiewq8"
+            class="svelte-1kobtom"
           >
              
             <span
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
               role="article"
             >
               <div
-                class="content svelte-9e8ghi"
+                class="content svelte-4r86n"
               >
                 <span
-                  class="artwork svelte-9e8ghi"
+                  class="artwork svelte-4r86n"
                 >
                   <img
-                    class="h-full w-full rounded-full hidden svelte-dtt58s"
+                    class="h-full w-full rounded-full hidden svelte-1psk6yi"
                     height="256"
                     loading="lazy"
                     width="256"
                   />
                    
                   <span
-                    class="h-full w-full svelte-dtt58s rounded-full"
+                    class="h-full w-full svelte-1psk6yi rounded-full"
                   >
                     <i
-                      class="material-icons svelte-dtt58s"
+                      class="material-icons svelte-1psk6yi"
                     >
                       person
                     </i>
@@ -1571,15 +1571,15 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
                 </span>
                  
                 <p
-                  class="controls svelte-9e8ghi"
+                  class="controls svelte-4r86n"
                 >
                    
                   <button
-                    class="primary iconOnly large svelte-1vd9h50"
+                    class="primary iconOnly large svelte-1e4q28k"
                     data-testid="play"
                   >
                     <i
-                      class="material-icons svelte-1vd9h50"
+                      class="material-icons svelte-1e4q28k"
                     >
                       play_arrow
                     </i>
@@ -1589,11 +1589,11 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
                   </button>
                    
                   <button
-                    class="primary iconOnly large svelte-1vd9h50"
+                    class="primary iconOnly large svelte-1e4q28k"
                     data-testid="enqueue"
                   >
                     <i
-                      class="material-icons svelte-1vd9h50"
+                      class="material-icons svelte-1e4q28k"
                     >
                       playlist_add
                     </i>
@@ -1605,16 +1605,16 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               </div>
                
               <header
-                class="svelte-9e8ghi"
+                class="svelte-4r86n"
               >
                 <h3
-                  class="svelte-9e8ghi"
+                  class="svelte-4r86n"
                 >
                   Ludwig Van Beethoven
                 </h3>
                  
                 <h4
-                  class="svelte-1vmk98n"
+                  class="svelte-rw2hde"
                   slot="details"
                 >
                   1 album
@@ -1624,22 +1624,22 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
              
           </li>
           <li
-            class="svelte-uiewq8"
+            class="svelte-1kobtom"
           >
              
             <span
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
               role="article"
             >
               <div
-                class="content svelte-9e8ghi"
+                class="content svelte-4r86n"
               >
                 <span
-                  class="artwork svelte-9e8ghi"
+                  class="artwork svelte-4r86n"
                 >
                   <img
                     alt="avatar.jpg"
-                    class="h-full w-full rounded-full svelte-dtt58s"
+                    class="h-full w-full rounded-full svelte-1psk6yi"
                     height="256"
                     loading="lazy"
                     src="avatar.jpg"
@@ -1650,15 +1650,15 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
                 </span>
                  
                 <p
-                  class="controls svelte-9e8ghi"
+                  class="controls svelte-4r86n"
                 >
                    
                   <button
-                    class="primary iconOnly large svelte-1vd9h50"
+                    class="primary iconOnly large svelte-1e4q28k"
                     data-testid="play"
                   >
                     <i
-                      class="material-icons svelte-1vd9h50"
+                      class="material-icons svelte-1e4q28k"
                     >
                       play_arrow
                     </i>
@@ -1668,11 +1668,11 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
                   </button>
                    
                   <button
-                    class="primary iconOnly large svelte-1vd9h50"
+                    class="primary iconOnly large svelte-1e4q28k"
                     data-testid="enqueue"
                   >
                     <i
-                      class="material-icons svelte-1vd9h50"
+                      class="material-icons svelte-1e4q28k"
                     >
                       playlist_add
                     </i>
@@ -1684,16 +1684,16 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               </div>
                
               <header
-                class="svelte-9e8ghi"
+                class="svelte-4r86n"
               >
                 <h3
-                  class="svelte-9e8ghi"
+                  class="svelte-4r86n"
                 >
                   Mademoiselle K
                 </h3>
                  
                 <h4
-                  class="svelte-1vmk98n"
+                  class="svelte-rw2hde"
                   slot="details"
                 >
                   2 albums
@@ -1703,31 +1703,31 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
              
           </li>
           <li
-            class="svelte-uiewq8"
+            class="svelte-1kobtom"
           >
              
             <span
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
               role="article"
             >
               <div
-                class="content svelte-9e8ghi"
+                class="content svelte-4r86n"
               >
                 <span
-                  class="artwork svelte-9e8ghi"
+                  class="artwork svelte-4r86n"
                 >
                   <img
-                    class="h-full w-full rounded-full hidden svelte-dtt58s"
+                    class="h-full w-full rounded-full hidden svelte-1psk6yi"
                     height="256"
                     loading="lazy"
                     width="256"
                   />
                    
                   <span
-                    class="h-full w-full svelte-dtt58s rounded-full"
+                    class="h-full w-full svelte-1psk6yi rounded-full"
                   >
                     <i
-                      class="material-icons svelte-dtt58s"
+                      class="material-icons svelte-1psk6yi"
                     >
                       person
                     </i>
@@ -1736,15 +1736,15 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
                 </span>
                  
                 <p
-                  class="controls svelte-9e8ghi"
+                  class="controls svelte-4r86n"
                 >
                    
                   <button
-                    class="primary iconOnly large svelte-1vd9h50"
+                    class="primary iconOnly large svelte-1e4q28k"
                     data-testid="play"
                   >
                     <i
-                      class="material-icons svelte-1vd9h50"
+                      class="material-icons svelte-1e4q28k"
                     >
                       play_arrow
                     </i>
@@ -1754,11 +1754,11 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
                   </button>
                    
                   <button
-                    class="primary iconOnly large svelte-1vd9h50"
+                    class="primary iconOnly large svelte-1e4q28k"
                     data-testid="enqueue"
                   >
                     <i
-                      class="material-icons svelte-1vd9h50"
+                      class="material-icons svelte-1e4q28k"
                     >
                       playlist_add
                     </i>
@@ -1770,16 +1770,16 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               </div>
                
               <header
-                class="svelte-9e8ghi"
+                class="svelte-4r86n"
               >
                 <h3
-                  class="svelte-9e8ghi"
+                  class="svelte-4r86n"
                 >
                   Yoko Kanno and the Seatbelts
                 </h3>
                  
                 <h4
-                  class="svelte-1vmk98n"
+                  class="svelte-rw2hde"
                   slot="details"
                 >
                   9 albums
@@ -1801,46 +1801,46 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
     </section>
      
     <section
-      class="svelte-jajdg"
+      class="svelte-1bpty66"
     >
       <span
-        class="undefined albums svelte-uiewq8"
+        class="undefined albums svelte-1kobtom"
       >
         <h3
-          class="svelte-uiewq8"
+          class="svelte-1kobtom"
         >
           3 albums
         </h3>
          
         <ul
-          class="svelte-uiewq8"
+          class="svelte-1kobtom"
         >
           <li
-            class="svelte-uiewq8"
+            class="svelte-1kobtom"
           >
              
             <span
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
               role="article"
             >
               <div
-                class="content svelte-9e8ghi"
+                class="content svelte-4r86n"
               >
                 <span
-                  class="artwork svelte-9e8ghi"
+                  class="artwork svelte-4r86n"
                 >
                   <img
-                    class="h-full w-full rounded-sm hidden svelte-dtt58s"
+                    class="h-full w-full rounded-sm hidden svelte-1psk6yi"
                     height="256"
                     loading="lazy"
                     width="256"
                   />
                    
                   <span
-                    class="h-full w-full svelte-dtt58s rounded-sm"
+                    class="h-full w-full svelte-1psk6yi rounded-sm"
                   >
                     <i
-                      class="material-icons svelte-dtt58s"
+                      class="material-icons svelte-1psk6yi"
                     >
                       music_note
                     </i>
@@ -1849,15 +1849,15 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
                 </span>
                  
                 <p
-                  class="controls svelte-9e8ghi"
+                  class="controls svelte-4r86n"
                 >
                    
                   <button
-                    class="primary iconOnly large svelte-1vd9h50"
+                    class="primary iconOnly large svelte-1e4q28k"
                     data-testid="play"
                   >
                     <i
-                      class="material-icons svelte-1vd9h50"
+                      class="material-icons svelte-1e4q28k"
                     >
                       play_arrow
                     </i>
@@ -1867,11 +1867,11 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
                   </button>
                    
                   <button
-                    class="primary iconOnly large svelte-1vd9h50"
+                    class="primary iconOnly large svelte-1e4q28k"
                     data-testid="enqueue"
                   >
                     <i
-                      class="material-icons svelte-1vd9h50"
+                      class="material-icons svelte-1e4q28k"
                     >
                       playlist_add
                     </i>
@@ -1883,16 +1883,16 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               </div>
                
               <header
-                class="svelte-9e8ghi"
+                class="svelte-4r86n"
               >
                 <h3
-                  class="svelte-9e8ghi"
+                  class="svelte-4r86n"
                 >
                   100 Best Karajan
                 </h3>
                  
                 <h4
-                  class="svelte-1vmk98n"
+                  class="svelte-rw2hde"
                   slot="details"
                 >
                   by 
@@ -1951,22 +1951,22 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
              
           </li>
           <li
-            class="svelte-uiewq8"
+            class="svelte-1kobtom"
           >
              
             <span
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
               role="article"
             >
               <div
-                class="content svelte-9e8ghi"
+                class="content svelte-4r86n"
               >
                 <span
-                  class="artwork svelte-9e8ghi"
+                  class="artwork svelte-4r86n"
                 >
                   <img
                     alt="cover.jpg"
-                    class="h-full w-full rounded-sm svelte-dtt58s"
+                    class="h-full w-full rounded-sm svelte-1psk6yi"
                     height="256"
                     loading="lazy"
                     src="cover.jpg"
@@ -1977,15 +1977,15 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
                 </span>
                  
                 <p
-                  class="controls svelte-9e8ghi"
+                  class="controls svelte-4r86n"
                 >
                    
                   <button
-                    class="primary iconOnly large svelte-1vd9h50"
+                    class="primary iconOnly large svelte-1e4q28k"
                     data-testid="play"
                   >
                     <i
-                      class="material-icons svelte-1vd9h50"
+                      class="material-icons svelte-1e4q28k"
                     >
                       play_arrow
                     </i>
@@ -1995,11 +1995,11 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
                   </button>
                    
                   <button
-                    class="primary iconOnly large svelte-1vd9h50"
+                    class="primary iconOnly large svelte-1e4q28k"
                     data-testid="enqueue"
                   >
                     <i
-                      class="material-icons svelte-1vd9h50"
+                      class="material-icons svelte-1e4q28k"
                     >
                       playlist_add
                     </i>
@@ -2011,16 +2011,16 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               </div>
                
               <header
-                class="svelte-9e8ghi"
+                class="svelte-4r86n"
               >
                 <h3
-                  class="svelte-9e8ghi"
+                  class="svelte-4r86n"
                 >
                   Black Orpheus
                 </h3>
                  
                 <h4
-                  class="svelte-1vmk98n"
+                  class="svelte-rw2hde"
                   slot="details"
                 >
                   by 
@@ -2039,31 +2039,31 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
              
           </li>
           <li
-            class="svelte-uiewq8"
+            class="svelte-1kobtom"
           >
              
             <span
-              class="svelte-9e8ghi"
+              class="svelte-4r86n"
               role="article"
             >
               <div
-                class="content svelte-9e8ghi"
+                class="content svelte-4r86n"
               >
                 <span
-                  class="artwork svelte-9e8ghi"
+                  class="artwork svelte-4r86n"
                 >
                   <img
-                    class="h-full w-full rounded-sm hidden svelte-dtt58s"
+                    class="h-full w-full rounded-sm hidden svelte-1psk6yi"
                     height="256"
                     loading="lazy"
                     width="256"
                   />
                    
                   <span
-                    class="h-full w-full svelte-dtt58s rounded-sm"
+                    class="h-full w-full svelte-1psk6yi rounded-sm"
                   >
                     <i
-                      class="material-icons svelte-dtt58s"
+                      class="material-icons svelte-1psk6yi"
                     >
                       music_note
                     </i>
@@ -2072,15 +2072,15 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
                 </span>
                  
                 <p
-                  class="controls svelte-9e8ghi"
+                  class="controls svelte-4r86n"
                 >
                    
                   <button
-                    class="primary iconOnly large svelte-1vd9h50"
+                    class="primary iconOnly large svelte-1e4q28k"
                     data-testid="play"
                   >
                     <i
-                      class="material-icons svelte-1vd9h50"
+                      class="material-icons svelte-1e4q28k"
                     >
                       play_arrow
                     </i>
@@ -2090,11 +2090,11 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
                   </button>
                    
                   <button
-                    class="primary iconOnly large svelte-1vd9h50"
+                    class="primary iconOnly large svelte-1e4q28k"
                     data-testid="enqueue"
                   >
                     <i
-                      class="material-icons svelte-1vd9h50"
+                      class="material-icons svelte-1e4q28k"
                     >
                       playlist_add
                     </i>
@@ -2106,16 +2106,16 @@ exports[`Toolshot routes/search/[searched].tools.svelte: Views/Search Results 1`
               </div>
                
               <header
-                class="svelte-9e8ghi"
+                class="svelte-4r86n"
               >
                 <h3
-                  class="svelte-9e8ghi"
+                  class="svelte-4r86n"
                 >
                   Distant Worlds - Music from Final Fantasy
                 </h3>
                  
                 <h4
-                  class="svelte-1vmk98n"
+                  class="svelte-rw2hde"
                   slot="details"
                 >
                   by 

--- a/common/ui/src/utils/connection.js
+++ b/common/ui/src/utils/connection.js
@@ -6,6 +6,7 @@ import { nanoid } from 'nanoid'
 
 let ws
 const messages$ = new BehaviorSubject({})
+const lastInvokation$ = new BehaviorSubject()
 
 /**
  * Connects to the server's Websocket.
@@ -77,6 +78,7 @@ export function send(data, failOnError = true) {
       throw new Error(`unestablished connection, call initConnection() first`)
     }
   } else {
+    lastInvokation$.next(data)
     ws.send(
       JSON.stringify(
         data.error
@@ -87,7 +89,9 @@ export function send(data, failOnError = true) {
   }
 }
 
-const lastInvokation$ = new BehaviorSubject()
+/**
+ * @yields {object} last invoked server method, with `invoked` , `args` and `id`
+ */
 export const lastInvokation = lastInvokation$.asObservable()
 
 /**

--- a/common/ui/tailwind.config.js
+++ b/common/ui/tailwind.config.js
@@ -1,7 +1,6 @@
 'use strict'
 
 module.exports = {
-  mode: 'jit',
   theme: { extend: {} },
   variants: {},
   plugins: []


### PR DESCRIPTION
### What's in there?
As part of #34 investigations, I found several bugs introduced in beta:

- [x] fix(ui): tailwind kit does not include utility classes
- [x] fix(ui): Player buttons sometimes get stuck
- [x] fix(ui): tutorial is broken since introducing broadcast button

### How to test?

To test the tutorial:
1. drop the db `rm ~/.config/melodie/db.sqlite3`
2. starts melodie again `npm start`

It should work properly until the end.

The tailwind css regression can be seen in atelier: `npm run atelier -w common/ui`. 
Check out broken image tools.