### PR TITLE
fix(ui): improves player's stablility

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Another option is to open it with Control-click: it'll immediately register the 
 
 ### Bugs and known issues
 
+1. Melodie desktop sometimes fails to download new tracks due to TOTP.
+
 1. When server is not reachable, attempts to establish new WebSocket connection takes longer and longer
 
 1. DMG package does not download updates: [it requires zip](https://github.com/electron-userland/electron-builder/issues/2199), and we cannot build zip because of [the accent in product name](https://github.com/electron-userland/electron-builder/issues/4306#issuecomment-717232761)...
@@ -474,12 +476,14 @@ Mélodie is referenced on these stores and hubs:
 - svelte-spa-router, and its dependency on regexparam, has been bother me for a very long time. When ran with jest, svelte-spa-router files must be transpiled by Svelte compiler, but they import regexparam as esm, and this lib doesn't expose such binding. One must replace the import with require, and this must only be done during test, because rollup will handle it properly.
   When receiving errors from svelte-jester, don't forget to clean jest cache with --cleanCache CLI option.
 
-- pino@7+ has a new concepts of transports, which run in a worker. Unfortunately, this does not play well when bundled in an [asar archive](https://github.com/electron/electron/issues/22446).
-  And because electron-builder's [asarUnpack](https://www.electron.build/configuration/configuration) does not remove the modules from the asar (it unpacks them in addition to embed them), I had to completely disable asar.
-
 - since v22.11.1, electron-builder fails to build the app on [Github worker](https://github.com/electron-userland/electron-builder/issues/6124). Fixing the version to 22.10.5 for the time being.
 
 - Tailwind is veeeeeeeeeeeery slow to compile. Svelte preprocessor can not handle it fast, making vite pretty slow when starting atelier (only the first load). More [information here](https://github.com/vitejs/vite/issues/5145). Moving to [Windi CSS](https://windicss.org/) speed the build time from 65 to 28 seconds!
+
+- The `Audio` element failed to play any music when coupled with `AudioContext`:
+  1.  Bluetooth must be enabled prior to starting the app (simply reload the app once enabled)
+  1.  `AudioContext` will build, but will not process any data.
+      Being running or suspended (as per Google's [policy](https://developer.chrome.com/blog/autoplay/#webaudio)) does not matter: rebuilding the context or building it on user interaction does not solve the issue as long as bluetooth is enabled
 
 #### How watch & diff works
 

--- a/common/core/lib/providers/local/index.js
+++ b/common/core/lib/providers/local/index.js
@@ -251,7 +251,10 @@ function watch(folders, logger) {
                 )
           )
         )
-        .subscribe(() => playlists.checkIntegrity())
+        .subscribe({
+          next: () => playlists.checkIntegrity(),
+          error: logger.error.bind(logger)
+        })
     )
   }
 }

--- a/common/ui/src/App.test.js
+++ b/common/ui/src/App.test.js
@@ -200,7 +200,7 @@ describe('App component', () => {
 
       const dialog = screen.queryByRole('dialog')
       expect(dialog).toBeInTheDocument()
-      userEvent.type(within(dialog).queryByRole('textbox'), `${otp}{enter}`)
+      userEvent.type(within(dialog).getByRole('spinbutton'), `${otp}{enter}`)
 
       expect(get(totp)).toEqual(otp.toString())
       expect(initConnection).toHaveBeenCalledTimes(2)

--- a/common/ui/src/components/BroadcastButton/BroadcastButton.test.js
+++ b/common/ui/src/components/BroadcastButton/BroadcastButton.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import { screen, render, fireEvent } from '@testing-library/svelte'
+import { screen, render, fireEvent, waitFor } from '@testing-library/svelte'
 import userEvent from '@testing-library/user-event'
 import html from 'svelte-htm'
 import faker from 'faker'
@@ -72,6 +72,7 @@ describe('BroadcastButton component', () => {
       isBroadcasting: false,
       address
     })
+    expect(releaseWakeLock).toHaveBeenCalledTimes(1)
     component.$on('click', handleClick)
     await component.$set({ isBroadcasting: true })
     expect(screen.queryByRole('menu')).toBeInTheDocument()
@@ -84,13 +85,15 @@ describe('BroadcastButton component', () => {
       expect.any(Object)
     )
 
+    expect(releaseWakeLock).toHaveBeenCalledTimes(1)
     component.$set({ isBroadcasting: false })
-    await sleep(250)
 
-    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
-    expect(screen.queryByRole('link')).not.toBeInTheDocument()
-    expect(screen.queryByText('wifi_off')).toBeInTheDocument()
-    expect(screen.queryByText('wifi')).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+      expect(screen.queryByRole('link')).not.toBeInTheDocument()
+      expect(screen.queryByText('wifi_off')).toBeInTheDocument()
+      expect(screen.queryByText('wifi')).not.toBeInTheDocument()
+    })
     expect(handleClick).not.toHaveBeenCalled()
     expect(toCanvas).toHaveBeenCalledTimes(1)
     expect(stayAwake).toHaveBeenCalledTimes(1)

--- a/common/ui/src/components/DisconnectionDialogue/DisconnectionDialogue.svelte
+++ b/common/ui/src/components/DisconnectionDialogue/DisconnectionDialogue.svelte
@@ -39,7 +39,7 @@
     <div class="otp">
       <h3>{$_('one time password')}</h3>
       <form on:submit|preventDefault={handleConnect}>
-        <TextInput on:input={handleInput} on:change focus />
+        <TextInput type="number" on:input={handleInput} on:change focus />
         <Button type="submit" icon="input" primary />
       </form>
     </div>

--- a/common/ui/src/components/Player/__snapshots__/Player.tools.shot
+++ b/common/ui/src/components/Player/__snapshots__/Player.tools.shot
@@ -298,7 +298,6 @@ exports[`Toolshot components/Player/Player.tools.svelte: With track list 1`] = `
            
           <button
             class="iconOnly noBorder svelte-11qpkf0"
-            disabled=""
           >
             <i
               class="material-icons svelte-11qpkf0"
@@ -312,7 +311,6 @@ exports[`Toolshot components/Player/Player.tools.svelte: With track list 1`] = `
            
           <button
             class="iconOnly large svelte-11qpkf0"
-            disabled=""
           >
             <i
               class="material-icons svelte-11qpkf0"
@@ -326,7 +324,6 @@ exports[`Toolshot components/Player/Player.tools.svelte: With track list 1`] = `
            
           <button
             class="iconOnly noBorder svelte-11qpkf0"
-            disabled=""
           >
             <i
               class="material-icons svelte-11qpkf0"


### PR DESCRIPTION
### What's in there?

The `Player` component has been very brittle when used with fluctuating connectivity. Buttons sometimes disables with no reasons, playing the last track suspends everything, and last but not least, reloading the app while bluetooth is enabled prevents from playing music.

Are included here:
- [x] fix(ui): suspended player on Chrome Android with bluetooth enabled
- [x] fix(ui): player controls are disabled when track list contains single track
- [x] fix(ui): player time does not reset when track reaches the end
- [x] fix(core): watcher errors bubble up to user. Errors encountered in watcher should be logged and ignored. Closes #38
- [x] feat(ui): uses number input when entering TOTP



### How to test?

Open Mélodie on Chrome Android, go in the wild and try it out!
