### PR TITLE
fix(site): download button and fav icons are missing

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -2,8 +2,6 @@ appId: org.feugy.melodie
 productName: Mélodie
 copyright: Copyright © 2021 ${author}
 
-asar: false
-
 files:
   - LICENSE
   - CHANGELOG.md

--- a/apps/site/src/components/DownloadButton/DownloadButtonItem.svelte
+++ b/apps/site/src/components/DownloadButton/DownloadButtonItem.svelte
@@ -6,6 +6,8 @@
   export let file
   export let baseUrl
 
+  const imageBaseUrl = BASE_URL
+
   const dispatch = createEventDispatcher()
 
   function handleClick() {
@@ -24,5 +26,5 @@
 </style>
 
 <div on:click={handleClick}>
-  <img src="logos/{os}.png" alt={os} /><span>{label}</span>
+  <img src="{imageBaseUrl}/logos/{os}.png" alt={os} /><span>{label}</span>
 </div>

--- a/apps/site/src/routes/index.svelte
+++ b/apps/site/src/routes/index.svelte
@@ -78,7 +78,7 @@
 <Sticky>
   <nav>
     <img
-      src="favicon.png"
+      src="{baseUrl}/favicon.png"
       alt={$_('alt.home')}
       on:click={() => {
         window.location.hash = ''

--- a/apps/site/src/tests/index/__snapshots__/index.tools.shot
+++ b/apps/site/src/tests/index/__snapshots__/index.tools.shot
@@ -15,7 +15,7 @@ exports[`Toolshot tests/index/index.tools.svelte: Site Page/Index 1`] = `
       <img
         alt="Mélodie logo - link to the page top"
         class="svelte-11kojun"
-        src="favicon.png"
+        src="/favicon.png"
       />
        
       <a

--- a/common/ui/src/components/Dropdown/Dropdown.svelte
+++ b/common/ui/src/components/Dropdown/Dropdown.svelte
@@ -240,7 +240,7 @@
   </Button>
 </span>
 {#if open && anchor && options && options.length}
-  <Portal>
+  <Portal target="body">
     <ul
       role="menu"
       tabindex="-1"


### PR DESCRIPTION
### What's in there?

![image](https://user-images.githubusercontent.com/186268/160981516-7fc268af-21f4-4355-8dc2-a44088ca8f99.png)

Are included here:
- fix(site): download button and fav icons are missing
- chore(desktop): restore asar compression
- chore(site): fixes broken tool for `DownloadButton`

### How to test?

For icons:
1. `cd apps/site`
2. `npm run build`
3. `npm run serve` then navigate to http://localhost:3000/melodie
   > Icons should be restored
4. stop and check the dev mode: `npm run dev` then navigate to http://localhost:3000
5. also check the atelier on http://localhost:3000/atelier

For asar
1. `cd apps/desktop`
2. `rm -rf dist`
3. `npm run release:artifacts`
4. then try out snap or the app image
   > Mélodie will fail starting with an error popup if pino can not write log (which it could not do in its previous versions)
