### PR TITLE
chore(core): logs more details on connection issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Another option is to open it with Control-click: it'll immediately register the 
 
 - progressive webapp
 
-- Consider yarn2, once svelte-preprocess is fixed
+- Consider yarn2/pnpm, once svelte-preprocess is fixed
 
 - search tooling to find deps version mismatch, and maintain package.json same version
 

--- a/common/core/package.json
+++ b/common/core/package.json
@@ -1,1 +1,55 @@
-{"name":"@melodie/core","version":"2.0.0","description":"Mélodie core, to manage music tracks","main":"lib/index.js","scripts":{"test":"jest --coverage --colors","test:dev":"jest --watch"},"dependencies":{"@vscode/sqlite3":"^5.0.8","ajv":"^8.11.0","chokidar":"^3.5.3","electron":"18.0.0","fastify":"^3.27.4","fastify-compress":"^4.0.1","fastify-cors":"^6.0.3","fastify-jwt":"^4.1.1","fastify-static":"^4.6.1","fastify-websocket":"^4.2.1","fs-extra":"^10.0.1","got":"^11.8.2","json-schema":"^0.4.0","klaw":"^4.0.1","knex":"^1.0.4","knex-migrate":"^1.7.4","mime-types":"^2.1.35","music-metadata":"^7.12.2","os-locale":"^5.0.0","otpauth":"^7.1.0","pino":"^7.9.2","pino-pretty":"^7.6.0","public-ip":"^4.0.4","rxjs":"^7.5.5","ws":"^8.5.0","xxhashjs":"^0.2.2"},"devDependencies":{"deepmerge":"^4.2.2","dotenv":"^16.0.0","faker":"^5.5.3","jest":"^27.2.4","jest-extended":"^2.0.0","jest-watch-typeahead":"^1.0.0","minimatch":"^3.1.2","nock":"^13.2.4","otpauth":"^7.0.6","stack-trace":"^0.0.10"},"lint-staged":{"**/__nocks__/*.json":["node scripts/remove-secrets"]}}
+{
+  "name": "@melodie/core",
+  "version": "2.0.0",
+  "description": "Mélodie core, to manage music tracks",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "jest --coverage --colors",
+    "test:dev": "jest --watch"
+  },
+  "dependencies": {
+    "@vscode/sqlite3": "^5.0.8",
+    "ajv": "^8.11.0",
+    "chokidar": "^3.5.3",
+    "electron": "18.0.0",
+    "fastify": "^3.27.4",
+    "fastify-compress": "^4.0.1",
+    "fastify-cors": "^6.0.3",
+    "fastify-jwt": "^4.1.1",
+    "fastify-static": "^4.6.1",
+    "fastify-websocket": "^4.2.1",
+    "fs-extra": "^10.0.1",
+    "got": "^11.8.2",
+    "json-schema": "^0.4.0",
+    "klaw": "^4.0.1",
+    "knex": "^1.0.4",
+    "knex-migrate": "^1.7.4",
+    "mime-types": "^2.1.35",
+    "music-metadata": "^7.12.2",
+    "os-locale": "^5.0.0",
+    "otpauth": "^7.1.0",
+    "pino": "^7.9.2",
+    "pino-pretty": "^7.6.0",
+    "public-ip": "^4.0.4",
+    "rxjs": "^7.5.5",
+    "ws": "^8.5.0",
+    "xxhashjs": "^0.2.2"
+  },
+  "devDependencies": {
+    "deepmerge": "^4.2.2",
+    "dotenv": "^16.0.0",
+    "faker": "^5.5.3",
+    "jest": "^27.2.4",
+    "jest-extended": "^2.0.0",
+    "jest-watch-typeahead": "^1.0.0",
+    "minimatch": "^3.1.2",
+    "nock": "^13.2.4",
+    "otpauth": "^7.0.6",
+    "stack-trace": "^0.0.10"
+  },
+  "lint-staged": {
+    "**/__nocks__/*.json": [
+      "node scripts/remove-secrets"
+    ]
+  }
+}

--- a/common/ui/src/components/DisconnectionDialogue/DisconnectionDialogue.svelte
+++ b/common/ui/src/components/DisconnectionDialogue/DisconnectionDialogue.svelte
@@ -12,14 +12,12 @@
   let otp = ''
 
   function handleInput({ target }) {
-    otp = target.value.replace(/\D/g, '')
-    target.value = otp
+    otp = target.value
   }
 
   function handleConnect() {
-    if (!connecting) {
-      dispatch('reconnect', otp)
-    }
+    dispatch('reconnect', otp.replace(/\D/g, ''))
+    otp = ''
   }
 </script>
 
@@ -39,8 +37,14 @@
     <div class="otp">
       <h3>{$_('one time password')}</h3>
       <form on:submit|preventDefault={handleConnect}>
-        <TextInput type="number" on:input={handleInput} on:change focus />
-        <Button type="submit" icon="input" primary />
+        <TextInput
+          type="number"
+          value={otp}
+          on:input={handleInput}
+          on:change
+          focus
+        />
+        <Button type="submit" icon="input" primary disabled={connecting} />
       </form>
     </div>
   </div>

--- a/common/ui/src/components/Player/Player.svelte
+++ b/common/ui/src/components/Player/Player.svelte
@@ -10,7 +10,7 @@
   import Shuffle from './Shuffle.svelte'
   import Repeat from './Repeat.svelte'
   import { isDesktop } from '../../stores/settings'
-  import { current, next, tracks } from '../../stores/track-queue'
+  import { current, tracks } from '../../stores/track-queue'
   import { playNext } from '../../stores/track-queue'
   import { screenSize, MD } from '../../stores/window'
   import { enhanceUrl } from '../../utils'
@@ -48,14 +48,8 @@
         player.load()
       }
     })
-    const nextSubscription = next.subscribe(next => {
-      if (next) {
-        fetch(enhanceUrl(next.data))
-      }
-    })
     return () => {
       currentSubscription.unsubscribe()
-      nextSubscription.unsubscribe()
     }
   })
 

--- a/common/ui/src/components/Player/Player.test.js
+++ b/common/ui/src/components/Player/Player.test.js
@@ -25,7 +25,6 @@ describe('Player component', () => {
   let gainNode
   let audioContext
   let observer
-  let fetch
 
   function renderPlayer() {
     render(html`<${Player} />`)
@@ -77,7 +76,6 @@ describe('Player component', () => {
     })
     clear()
     invoke.mockResolvedValueOnce({ total: 0, results: [] })
-    fetch = jest.spyOn(window, 'fetch')
   })
 
   afterEach(() => {
@@ -94,7 +92,6 @@ describe('Player component', () => {
     expect(audio).toHaveAttribute('src', trackListData[0].data)
 
     expect(get(current)).toEqual(trackListData[0])
-    expect(fetch).toHaveBeenCalledWith(trackListData[1].data)
 
     await userEvent.click(await screen.findByText('pause'))
 
@@ -103,7 +100,6 @@ describe('Player component', () => {
     await userEvent.click(screen.getByText('play_arrow'))
 
     expect(get(current)).toEqual(trackListData[0])
-    expect(fetch).toHaveBeenCalledTimes(1)
   })
 
   it('mutes and unmute volume', async () => {
@@ -122,12 +118,9 @@ describe('Player component', () => {
     add(trackListData)
 
     renderPlayer()
-    expect(fetch).toHaveBeenNthCalledWith(1, trackListData[1].data)
     await userEvent.click(screen.getByText('skip_next'))
-    expect(fetch).toHaveBeenNthCalledWith(2, trackListData[2].data)
 
     expect(get(current)).toEqual(trackListData[1])
-    expect(fetch).toHaveBeenCalledTimes(2)
   })
 
   it('goes to previous track', async () => {
@@ -136,12 +129,9 @@ describe('Player component', () => {
     expect(get(current)).toEqual(trackListData[2])
 
     renderPlayer()
-    expect(fetch).toHaveBeenNthCalledWith(1, trackListData[3].data)
     await userEvent.click(screen.getByText('skip_previous'))
-    expect(fetch).toHaveBeenNthCalledWith(2, trackListData[2].data)
 
     expect(get(current)).toEqual(trackListData[1])
-    expect(fetch).toHaveBeenCalledTimes(2)
   })
 
   it('can change volume', async () => {

--- a/common/ui/src/stores/settings.js
+++ b/common/ui/src/stores/settings.js
@@ -73,7 +73,7 @@ async function connect(address, reconnectDelay) {
   connected$.next(Boolean(settings))
 }
 
-export async function init(address, totpSecret, totp, reconnectDelay = 5000) {
+export async function init(address, totpSecret, totp, reconnectDelay = 1000) {
   cleanPending()
   connected$.next(null)
   await new Promise(resolve => {

--- a/common/ui/src/utils/connection.test.js
+++ b/common/ui/src/utils/connection.test.js
@@ -74,7 +74,7 @@ describe('connection utilities', () => {
     server.on('connection', ws => ws.send(JSON.stringify({ token, settings })))
     setServerUpgrade(handleUpgrade)
     serverUrl = `ws://localhost:${server.address().port}`
-    localStorage.clear()
+    sessionStorage.clear()
   })
 
   afterEach(() => {
@@ -102,7 +102,7 @@ describe('connection utilities', () => {
       settings
     )
     const client = await connection
-    expect(localStorage.getItem('token')).toEqual(token)
+    expect(sessionStorage.getItem('token')).toEqual(token)
 
     const closure = new Promise(resolve => client.on('close', resolve))
     closeConnection()
@@ -115,21 +115,21 @@ describe('connection utilities', () => {
   it('connects to WebSocket server with Totp', async () => {
     await initConnection(serverUrl, totp, handleLostConnection)
     expect(handleUpgrade).toHaveBeenCalledWith({ totp })
-    expect(localStorage.getItem('token')).toEqual(token)
+    expect(sessionStorage.getItem('token')).toEqual(token)
   })
 
   it('connects to WebSocket server with token', async () => {
-    localStorage.setItem('token', token)
+    sessionStorage.setItem('token', token)
     await initConnection(serverUrl, null, handleLostConnection)
     expect(handleUpgrade).toHaveBeenCalledWith({ token })
-    expect(localStorage.getItem('token')).toEqual(token)
+    expect(sessionStorage.getItem('token')).toEqual(token)
   })
 
   it('connects to WebSocket server with token and Totp', async () => {
-    localStorage.setItem('token', token)
+    sessionStorage.setItem('token', token)
     await initConnection(serverUrl, totp, handleLostConnection)
     expect(handleUpgrade).toHaveBeenCalledWith({ token, totp })
-    expect(localStorage.getItem('token')).toEqual(token)
+    expect(sessionStorage.getItem('token')).toEqual(token)
   })
 
   it('throws when initializing connection twice', async () => {
@@ -284,11 +284,11 @@ describe('connection utilities', () => {
       ws = client
     })
     await initConnection(serverUrl, totp, handleLostConnection)
-    expect(localStorage.getItem('token')).toEqual(token)
+    expect(sessionStorage.getItem('token')).toEqual(token)
 
     ws.send(JSON.stringify({ token: newToken }))
     await sleep()
-    expect(localStorage.getItem('token')).toEqual(newToken)
+    expect(sessionStorage.getItem('token')).toEqual(newToken)
     expect(errorSpy).not.toHaveBeenCalled()
     expect(handleLostConnection).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
### 📖 What's in there?

I'm still having reconnection issues from my phone when running outside.
This brings a bit more logs, and a potential fix for parallel disconnection handling

Are included here:

- chore(core): logs more details on connection issues
- chore(ui): reset `DisconnectionDialogue` OTP value on submit
- chore(ui): stops fetching next track since it does not cache it
- chore(ui): shortens reconnection delay
- chore(ui): prevents connection lost handlers in cascade

### 🧪  How to test?

Go run outside! All local, manual testing is unable to reproduce the issues.

<!--
### Notes to reviewers

If needed, uncomment and describe here any specific points you'd like to draw your reviewers attention on.
Otherwise,
-->
